### PR TITLE
SYSTEMS-1761: Add StringTemplate support to the Bender Config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ target
 .classpath
 .project
 *.swp
+*.iml
+.idea
 bin
 tmp
 dependency-reduced-pom.xml

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -155,5 +155,12 @@
       <version>${mockito-all.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.antlr/stringtemplate -->
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>ST4</artifactId>
+      <version>${stringtemplate.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/core/src/test/java/com/nextdoor/bender/config/ConfigurationTest.java
+++ b/core/src/test/java/com/nextdoor/bender/config/ConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright $year Nextdoor.com, Inc
+ */
+
+package com.nextdoor.bender.config;
+
+import static junit.framework.TestCase.assertEquals;
+
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import com.nextdoor.bender.handler.BaseHandler;
+
+public class ConfigurationTest {
+
+  @Rule
+  public final EnvironmentVariables envVars = new EnvironmentVariables();
+
+  @Test
+  public void testStringTemplatesInConfig() throws ConfigurationException, ClassNotFoundException {
+    envVars.set("CUSTOM_SOURCE_NAME", "TestSourceName");
+    BenderConfig config = BenderConfig.load(BaseHandler.class, "/config/config_with_env.json");
+
+    List<SourceConfig> sources = config.getSources();
+    assertEquals(sources.size(), 1);
+    assertEquals(sources.get(0).getName(), "TestSourceName");
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void testMissingStringTemplatesInConfig() throws ConfigurationException, ClassNotFoundException {
+    BenderConfig.load(BaseHandler.class, "/config/config_with_env.json");
+  }
+}

--- a/core/src/test/resources/config/config_with_env.json
+++ b/core/src/test/resources/config/config_with_env.json
@@ -1,0 +1,31 @@
+{
+  "handler": {
+    "config_name": "DummyHandlerHelper$DummyHandler"
+  },
+  "sources": [
+    {
+      "name": "<CUSTOM_SOURCE_NAME>",
+      "source_regex": ".*",
+      "deserializer": {
+        "config_name": "DummyDeserializerHelper$DummyDeserializerConfig"
+      },
+      "operations": [
+        {
+          "config_name": "DummyOperationHelper$DummyOperationConfig"
+        }
+      ]
+    }
+  ],
+  "wrapper": {
+    "config_name": "DummyWrapperHelper$DummyWrapperConfig"
+  },
+  "serializer": {
+    "config_name": "DummySerializerHelper$DummySerializerConfig"
+  },
+  "transport": {
+    "config_name": "DummyTransportHelper$DummyTransporterConfig",
+    "threads": 1
+  },
+  "reporters": [
+  ]
+}

--- a/itests/src/test/java/com/nextdoor/bender/config/ConfigurationTest.java
+++ b/itests/src/test/java/com/nextdoor/bender/config/ConfigurationTest.java
@@ -44,4 +44,5 @@ public class ConfigurationTest {
       assertNotNull(s.getSourceRegex());
     }
   }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <retry4j.version>0.6.2</retry4j.version>
     <s3proxy.version>1.5.3</s3proxy.version>
     <system-rules.version>1.16.0</system-rules.version>
+    <stringtemplate.version>4.0.8</stringtemplate.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Adds support to Bender Config files for using StringTemplate and
System.getenv() to replace certain strings in your config file with
environment variables. This seems to basically function now - but needs
more tests, as well as some error handling to make it obvious when you
have neglected to supply the missing environment variable.

@stlava quick pre-review to lemme know if I'm going down the right path?