### PR TITLE
Add support for encrypted config values

### DIFF
--- a/core/src/main/java/com/nextdoor/bender/config/BenderConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/config/BenderConfig.java
@@ -53,6 +53,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import com.nextdoor.bender.auth.AuthConfig;
 import com.nextdoor.bender.aws.AmazonS3ClientFactory;
+import com.nextdoor.bender.config.value.ValueConfig;
 import com.nextdoor.bender.deserializer.DeserializerConfig;
 import com.nextdoor.bender.handler.HandlerConfig;
 import com.nextdoor.bender.ipc.TransportConfig;
@@ -124,6 +125,7 @@ public class BenderConfig {
       subtypes.addAll(ImmutableList.copyOf(AbstractConfig.getSubtypes(TransportConfig.class)));
       subtypes.addAll(ImmutableList.copyOf(AbstractConfig.getSubtypes(ReporterConfig.class)));
       subtypes.addAll(ImmutableList.copyOf(AbstractConfig.getSubtypes(AuthConfig.class)));
+      subtypes.addAll(ImmutableList.copyOf(AbstractConfig.getSubtypes(ValueConfig.class)));
 
       /*
        * Sort the subtypes so that the order is deterministic. Without this locally generated

--- a/core/src/main/java/com/nextdoor/bender/config/value/KmsValueConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/config/value/KmsValueConfig.java
@@ -22,13 +22,19 @@ import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import com.nextdoor.bender.config.ConfigurationException;
 import com.nextdoor.bender.utils.Passwords;
 
 @JsonTypeName("KmsValue")
 public class KmsValueConfig extends ValueConfig<KmsValueConfig> {
+  @JsonSchemaDescription("AWS region associated with the KMS key used to encrypt the value.")
   @JsonProperty(required = true)
   private Regions region;
+
+  @JsonSchemaDescription("KMS encrypted value.")
+  @JsonProperty(required = true)
+  protected String value;
 
   @JsonIgnore
   private boolean decrypted = false;

--- a/core/src/main/java/com/nextdoor/bender/config/value/KmsValueConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/config/value/KmsValueConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2017 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.config.value;
+
+import java.io.UnsupportedEncodingException;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.nextdoor.bender.config.ConfigurationException;
+import com.nextdoor.bender.utils.Passwords;
+
+@JsonTypeName("KmsValue")
+public class KmsValueConfig extends ValueConfig<KmsValueConfig> {
+  @JsonProperty(required = true)
+  private Regions region;
+
+  @JsonIgnore
+  private boolean decrypted = false;
+
+  public String getValue() {
+    if (this.value == null) {
+      return value;
+    }
+
+    /*
+     * Ensure that the value is only decrypted once regardless of usage. This prevents KMS from
+     * being called over and over from within the function to decrypt the same field.
+     */
+    if (!this.decrypted) {
+      try {
+        this.value = Passwords.decrypt(this.value, Region.getRegion(this.region));
+      } catch (UnsupportedEncodingException e) {
+        throw new ConfigurationException("Unable to decrypt", e);
+      }
+      this.decrypted = true;
+    }
+
+    return this.value;
+  }
+
+  public Regions getRegion() {
+    return this.region;
+  }
+
+  public void setRegion(Regions region) {
+    this.region = region;
+  }
+}

--- a/core/src/main/java/com/nextdoor/bender/config/value/StringValueConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/config/value/StringValueConfig.java
@@ -13,18 +13,17 @@
  *
  */
 
-package com.nextdoor.bender.utils;
+package com.nextdoor.bender.config.value;
 
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.io.UnsupportedEncodingException;
+@JsonTypeName("StringValue")
+public class StringValueConfig extends ValueConfig<StringValueConfig> {
+  public StringValueConfig() {
 
-import org.junit.Test;
+  }
 
-public class PasswordsTest {
-
-  @Test
-  public void testNonKMSPassword() throws UnsupportedEncodingException {
-    assertEquals("foo", Passwords.getPassword("foo"));
+  public StringValueConfig(String value) {
+    this.value = value;
   }
 }

--- a/core/src/main/java/com/nextdoor/bender/config/value/ValueConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/config/value/ValueConfig.java
@@ -13,33 +13,25 @@
  *
  */
 
-package com.nextdoor.bender.auth;
+package com.nextdoor.bender.config.value;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.nextdoor.bender.config.value.ValueConfig;
+import com.nextdoor.bender.config.AbstractConfig;
 
-@JsonTypeName("UserPassAuth")
-public class BasicHttpAuthConfig extends HttpAuthConfig<BasicHttpAuthConfig> {
+public class ValueConfig<T> extends AbstractConfig<T> {
   @JsonProperty(required = true)
-  private String username;
+  protected String value;
 
-  @JsonProperty(required = true)
-  private ValueConfig<?> password;
-
-  public String getUsername() {
-    return username;
+  public String getValue() {
+    return this.value;
   }
 
-  public void setUsername(String username) {
-    this.username = username;
+  public void setValue(String value) {
+    this.value = value;
   }
 
-  public ValueConfig<?> getPassword() {
-    return password;
-  }
-
-  public void setPassword(ValueConfig password) {
-    this.password = password;
+  @Override
+  public String toString() {
+    return getValue();
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3447,7 +3447,8 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>KMS encrypted value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -3481,7 +3482,8 @@ function sourceButton(element) {
                 <span class="type-enum">CA_CENTRAL_1</span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>AWS region associated with the KMS key used to encrypt the value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -3504,7 +3506,8 @@ function sourceButton(element) {
       "default": "KmsValue"
     },
     "value": {
-      "type": "string"
+      "type": "string",
+      "description": "KMS encrypted value."
     },
     "region": {
       "type": "string",
@@ -3525,7 +3528,8 @@ function sourceButton(element) {
         "SA_EAST_1",
         "CN_NORTH_1",
         "CA_CENTRAL_1"
-      ]
+      ],
+      "description": "AWS region associated with the KMS key used to encrypt the value."
     }
   },
   "title": "KmsValue",
@@ -4816,7 +4820,8 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>KMS encrypted value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -4850,7 +4855,8 @@ function sourceButton(element) {
                 <span class="type-enum">CA_CENTRAL_1</span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>AWS region associated with the KMS key used to encrypt the value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -4873,7 +4879,8 @@ function sourceButton(element) {
       "default": "KmsValue"
     },
     "value": {
-      "type": "string"
+      "type": "string",
+      "description": "KMS encrypted value."
     },
     "region": {
       "type": "string",
@@ -4894,7 +4901,8 @@ function sourceButton(element) {
         "SA_EAST_1",
         "CN_NORTH_1",
         "CA_CENTRAL_1"
-      ]
+      ],
+      "description": "AWS region associated with the KMS key used to encrypt the value."
     }
   },
   "title": "KmsValue",
@@ -5693,7 +5701,8 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>KMS encrypted value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -5727,7 +5736,8 @@ function sourceButton(element) {
                 <span class="type-enum">CA_CENTRAL_1</span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>AWS region associated with the KMS key used to encrypt the value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -5750,7 +5760,8 @@ function sourceButton(element) {
       "default": "KmsValue"
     },
     "value": {
-      "type": "string"
+      "type": "string",
+      "description": "KMS encrypted value."
     },
     "region": {
       "type": "string",
@@ -5771,7 +5782,8 @@ function sourceButton(element) {
         "SA_EAST_1",
         "CN_NORTH_1",
         "CA_CENTRAL_1"
-      ]
+      ],
+      "description": "AWS region associated with the KMS key used to encrypt the value."
     }
   },
   "title": "KmsValue",
@@ -6431,7 +6443,8 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>KMS encrypted value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -6465,7 +6478,8 @@ function sourceButton(element) {
                 <span class="type-enum">CA_CENTRAL_1</span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>AWS region associated with the KMS key used to encrypt the value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -6488,7 +6502,8 @@ function sourceButton(element) {
       "default": "KmsValue"
     },
     "value": {
-      "type": "string"
+      "type": "string",
+      "description": "KMS encrypted value."
     },
     "region": {
       "type": "string",
@@ -6509,7 +6524,8 @@ function sourceButton(element) {
         "SA_EAST_1",
         "CN_NORTH_1",
         "CA_CENTRAL_1"
-      ]
+      ],
+      "description": "AWS region associated with the KMS key used to encrypt the value."
     }
   },
   "title": "KmsValue",
@@ -7144,7 +7160,8 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>KMS encrypted value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -7178,7 +7195,8 @@ function sourceButton(element) {
                 <span class="type-enum">CA_CENTRAL_1</span>
 
                 </div>
-                <div class="signature-description desc"></div>
+                <div class="signature-description desc"><p>AWS region associated with the KMS key used to encrypt the value.</p>
+</div>
             </div>
             <div class="signature-box-container">
             </div>
@@ -7201,7 +7219,8 @@ function sourceButton(element) {
       "default": "KmsValue"
     },
     "value": {
-      "type": "string"
+      "type": "string",
+      "description": "KMS encrypted value."
     },
     "region": {
       "type": "string",
@@ -7222,7 +7241,8 @@ function sourceButton(element) {
         "SA_EAST_1",
         "CN_NORTH_1",
         "CA_CENTRAL_1"
-      ]
+      ],
+      "description": "AWS region associated with the KMS key used to encrypt the value."
     }
   },
   "title": "KmsValue",
@@ -9258,7 +9278,8 @@ function sourceButton(element) {
           "default": "KmsValue"
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "KMS encrypted value."
         },
         "region": {
           "type": "string",
@@ -9279,7 +9300,8 @@ function sourceButton(element) {
             "SA_EAST_1",
             "CN_NORTH_1",
             "CA_CENTRAL_1"
-          ]
+          ],
+          "description": "AWS region associated with the KMS key used to encrypt the value."
         }
       },
       "title": "KmsValue",

--- a/docs/index.html
+++ b/docs/index.html
@@ -3216,8 +3216,8 @@ function sourceButton(element) {
 
                             <span class="type-keyword">map</span>
         <span class="type-keyword"></span>
-            <span class="signature-type-string">
-                string
+            <span class="signature-type-">
+                
             </span>
             <span class="type-keyword">
                 
@@ -3225,7 +3225,7 @@ function sourceButton(element) {
             <br>
 
                 </div>
-                <div class="signature-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+                <div class="signature-description desc"><p>HTTP headers to include.</p>
 </div>
             </div>
             <div class="signature-box-container">
@@ -3234,7 +3234,7 @@ function sourceButton(element) {
     <div class="box-header box-1">
         <div class="box-title" ref="">
             
-            <div class="box-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+            <div class="box-description desc"><p>HTTP headers to include.</p>
 </div>
             <div class="end"></div>
         </div>
@@ -3263,9 +3263,16 @@ function sourceButton(element) {
         <pre class="json-schema">{
   "type": "object",
   "additionalProperties": {
-    "type": "string"
+    "oneOf": [
+      {
+        "$ref": "#/definitions/KmsValueConfig"
+      },
+      {
+        "$ref": "#/definitions/StringValueConfig"
+      }
+    ]
   },
-  "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+  "description": "HTTP headers to include."
 }</pre>
     </div>
 </div>
@@ -3319,7 +3326,7 @@ function sourceButton(element) {
                 <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">UserPassAuth</span>
 
                 </div>
-                <div class="signature-description desc"><p>Username and password used for use with http basic auth. If encrypting password with KMS then prefix password field with 'KMS='.</p>
+                <div class="signature-description desc"><p>Username and password used for use with http basic auth.</p>
 </div>
             </div>
             <div class="signature-box-container">
@@ -3381,6 +3388,199 @@ function sourceButton(element) {
             <div class="signature-header">
                 <div class="property-name required">password</div>
                 <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">KmsValue</span>
+        <span class="type-keyword"></span>
+                <span boxid="2" class="box-2 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">KmsValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">KmsValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">KmsValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">region</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">enum</span>
+                <span class="type-enum">GovCloud</span>
+                <span class="type-enum">US_EAST_1</span>
+                <span class="type-enum">US_EAST_2</span>
+                <span class="type-enum">US_WEST_1</span>
+                <span class="type-enum">US_WEST_2</span>
+                <span class="type-enum">EU_WEST_1</span>
+                <span class="type-enum">EU_WEST_2</span>
+                <span class="type-enum">EU_CENTRAL_1</span>
+                <span class="type-enum">AP_SOUTH_1</span>
+                <span class="type-enum">AP_SOUTHEAST_1</span>
+                <span class="type-enum">AP_SOUTHEAST_2</span>
+                <span class="type-enum">AP_NORTHEAST_1</span>
+                <span class="type-enum">AP_NORTHEAST_2</span>
+                <span class="type-enum">SA_EAST_1</span>
+                <span class="type-enum">CN_NORTH_1</span>
+                <span class="type-enum">CA_CENTRAL_1</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "KmsValue"
+      ],
+      "default": "KmsValue"
+    },
+    "value": {
+      "type": "string"
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "GovCloud",
+        "US_EAST_1",
+        "US_EAST_2",
+        "US_WEST_1",
+        "US_WEST_2",
+        "EU_WEST_1",
+        "EU_WEST_2",
+        "EU_CENTRAL_1",
+        "AP_SOUTH_1",
+        "AP_SOUTHEAST_1",
+        "AP_SOUTHEAST_2",
+        "AP_NORTHEAST_1",
+        "AP_NORTHEAST_2",
+        "SA_EAST_1",
+        "CN_NORTH_1",
+        "CA_CENTRAL_1"
+      ]
+    }
+  },
+  "title": "KmsValue",
+  "required": [
+    "type",
+    "value",
+    "region"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+                <div class="box-container" boxid="2">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-2">
+        <div class="box-title" ref="">
+            <div class="box-name ">StringValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">StringValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
                                    <span class="signature-type-string">
                string
             </span>
@@ -3407,6 +3607,40 @@ function sourceButton(element) {
     "type": {
       "type": "string",
       "enum": [
+        "StringValue"
+      ],
+      "default": "StringValue"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "StringValue",
+  "required": [
+    "type",
+    "value"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
         "UserPassAuth"
       ],
       "default": "UserPassAuth"
@@ -3415,7 +3649,14 @@ function sourceButton(element) {
       "type": "string"
     },
     "password": {
-      "type": "string"
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KmsValueConfig"
+        },
+        {
+          "$ref": "#/definitions/StringValueConfig"
+        }
+      ]
     }
   },
   "title": "UserPassAuth",
@@ -3424,6 +3665,69 @@ function sourceButton(element) {
     "username",
     "password"
   ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_string_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-string">
+                string
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
 }</pre>
     </div>
 </div>
@@ -3506,9 +3810,16 @@ function sourceButton(element) {
     "http_headers": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/KmsValueConfig"
+          },
+          {
+            "$ref": "#/definitions/StringValueConfig"
+          }
+        ]
       },
-      "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+      "description": "HTTP headers to include."
     },
     "path": {
       "type": "string",
@@ -3524,7 +3835,13 @@ function sourceButton(element) {
           "$ref": "#/definitions/BasicHttpAuthConfig"
         }
       ],
-      "description": "Username and password used for use with http basic auth. If encrypting password with KMS then prefix password field with 'KMS='."
+      "description": "Username and password used for use with http basic auth."
+    },
+    "http_string_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "title": "HTTP",
@@ -4148,8 +4465,8 @@ function sourceButton(element) {
 
                             <span class="type-keyword">map</span>
         <span class="type-keyword"></span>
-            <span class="signature-type-string">
-                string
+            <span class="signature-type-">
+                
             </span>
             <span class="type-keyword">
                 
@@ -4157,7 +4474,7 @@ function sourceButton(element) {
             <br>
 
                 </div>
-                <div class="signature-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+                <div class="signature-description desc"><p>HTTP headers to include.</p>
 </div>
             </div>
             <div class="signature-box-container">
@@ -4166,7 +4483,7 @@ function sourceButton(element) {
     <div class="box-header box-1">
         <div class="box-title" ref="">
             
-            <div class="box-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+            <div class="box-description desc"><p>HTTP headers to include.</p>
 </div>
             <div class="end"></div>
         </div>
@@ -4195,9 +4512,16 @@ function sourceButton(element) {
         <pre class="json-schema">{
   "type": "object",
   "additionalProperties": {
-    "type": "string"
+    "oneOf": [
+      {
+        "$ref": "#/definitions/KmsValueConfig"
+      },
+      {
+        "$ref": "#/definitions/StringValueConfig"
+      }
+    ]
   },
-  "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+  "description": "HTTP headers to include."
 }</pre>
     </div>
 </div>
@@ -4433,6 +4757,199 @@ function sourceButton(element) {
             <div class="signature-header">
                 <div class="property-name required">password</div>
                 <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">KmsValue</span>
+        <span class="type-keyword"></span>
+                <span boxid="2" class="box-2 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">KmsValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">KmsValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">KmsValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">region</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">enum</span>
+                <span class="type-enum">GovCloud</span>
+                <span class="type-enum">US_EAST_1</span>
+                <span class="type-enum">US_EAST_2</span>
+                <span class="type-enum">US_WEST_1</span>
+                <span class="type-enum">US_WEST_2</span>
+                <span class="type-enum">EU_WEST_1</span>
+                <span class="type-enum">EU_WEST_2</span>
+                <span class="type-enum">EU_CENTRAL_1</span>
+                <span class="type-enum">AP_SOUTH_1</span>
+                <span class="type-enum">AP_SOUTHEAST_1</span>
+                <span class="type-enum">AP_SOUTHEAST_2</span>
+                <span class="type-enum">AP_NORTHEAST_1</span>
+                <span class="type-enum">AP_NORTHEAST_2</span>
+                <span class="type-enum">SA_EAST_1</span>
+                <span class="type-enum">CN_NORTH_1</span>
+                <span class="type-enum">CA_CENTRAL_1</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "KmsValue"
+      ],
+      "default": "KmsValue"
+    },
+    "value": {
+      "type": "string"
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "GovCloud",
+        "US_EAST_1",
+        "US_EAST_2",
+        "US_WEST_1",
+        "US_WEST_2",
+        "EU_WEST_1",
+        "EU_WEST_2",
+        "EU_CENTRAL_1",
+        "AP_SOUTH_1",
+        "AP_SOUTHEAST_1",
+        "AP_SOUTHEAST_2",
+        "AP_NORTHEAST_1",
+        "AP_NORTHEAST_2",
+        "SA_EAST_1",
+        "CN_NORTH_1",
+        "CA_CENTRAL_1"
+      ]
+    }
+  },
+  "title": "KmsValue",
+  "required": [
+    "type",
+    "value",
+    "region"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+                <div class="box-container" boxid="2">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-2">
+        <div class="box-title" ref="">
+            <div class="box-name ">StringValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">StringValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
                                    <span class="signature-type-string">
                string
             </span>
@@ -4459,6 +4976,40 @@ function sourceButton(element) {
     "type": {
       "type": "string",
       "enum": [
+        "StringValue"
+      ],
+      "default": "StringValue"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "StringValue",
+  "required": [
+    "type",
+    "value"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
         "UserPassAuth"
       ],
       "default": "UserPassAuth"
@@ -4467,7 +5018,14 @@ function sourceButton(element) {
       "type": "string"
     },
     "password": {
-      "type": "string"
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KmsValueConfig"
+        },
+        {
+          "$ref": "#/definitions/StringValueConfig"
+        }
+      ]
     }
   },
   "title": "UserPassAuth",
@@ -4556,6 +5114,69 @@ function sourceButton(element) {
 </div>
             </div>
             <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_string_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-string">
+                string
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
             </div>
         </div>
         <div class="signature">
@@ -4653,9 +5274,16 @@ function sourceButton(element) {
     "http_headers": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/KmsValueConfig"
+          },
+          {
+            "$ref": "#/definitions/StringValueConfig"
+          }
+        ]
       },
-      "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+      "description": "HTTP headers to include."
     },
     "auth_config": {
       "oneOf": [
@@ -4684,6 +5312,12 @@ function sourceButton(element) {
     "index_time_format": {
       "type": "string",
       "description": "Java time format to append to index name."
+    },
+    "http_string_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "use_hashid": {
       "type": "boolean",
@@ -4930,8 +5564,8 @@ function sourceButton(element) {
 
                             <span class="type-keyword">map</span>
         <span class="type-keyword"></span>
-            <span class="signature-type-string">
-                string
+            <span class="signature-type-">
+                
             </span>
             <span class="type-keyword">
                 
@@ -4939,7 +5573,7 @@ function sourceButton(element) {
             <br>
 
                 </div>
-                <div class="signature-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+                <div class="signature-description desc"><p>HTTP headers to include.</p>
 </div>
             </div>
             <div class="signature-box-container">
@@ -4948,7 +5582,7 @@ function sourceButton(element) {
     <div class="box-header box-1">
         <div class="box-title" ref="">
             
-            <div class="box-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+            <div class="box-description desc"><p>HTTP headers to include.</p>
 </div>
             <div class="end"></div>
         </div>
@@ -4977,9 +5611,16 @@ function sourceButton(element) {
         <pre class="json-schema">{
   "type": "object",
   "additionalProperties": {
-    "type": "string"
+    "oneOf": [
+      {
+        "$ref": "#/definitions/KmsValueConfig"
+      },
+      {
+        "$ref": "#/definitions/StringValueConfig"
+      }
+    ]
   },
-  "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+  "description": "HTTP headers to include."
 }</pre>
     </div>
 </div>
@@ -4992,6 +5633,58 @@ function sourceButton(element) {
             <div class="signature-header">
                 <div class="property-name required">token</div>
                 <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">KmsValue</span>
+        <span class="type-keyword"></span>
+                <span boxid="2" class="box-2 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"><p>Scalyr auth token.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">KmsValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">KmsValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">KmsValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
                                    <span class="signature-type-string">
                string
             </span>
@@ -5000,10 +5693,185 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"><p>Scalyr auth token. If value is kms encrypted prefix with 'KMS='.</p>
-</div>
+                <div class="signature-description desc"></div>
             </div>
             <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">region</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">enum</span>
+                <span class="type-enum">GovCloud</span>
+                <span class="type-enum">US_EAST_1</span>
+                <span class="type-enum">US_EAST_2</span>
+                <span class="type-enum">US_WEST_1</span>
+                <span class="type-enum">US_WEST_2</span>
+                <span class="type-enum">EU_WEST_1</span>
+                <span class="type-enum">EU_WEST_2</span>
+                <span class="type-enum">EU_CENTRAL_1</span>
+                <span class="type-enum">AP_SOUTH_1</span>
+                <span class="type-enum">AP_SOUTHEAST_1</span>
+                <span class="type-enum">AP_SOUTHEAST_2</span>
+                <span class="type-enum">AP_NORTHEAST_1</span>
+                <span class="type-enum">AP_NORTHEAST_2</span>
+                <span class="type-enum">SA_EAST_1</span>
+                <span class="type-enum">CN_NORTH_1</span>
+                <span class="type-enum">CA_CENTRAL_1</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "KmsValue"
+      ],
+      "default": "KmsValue"
+    },
+    "value": {
+      "type": "string"
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "GovCloud",
+        "US_EAST_1",
+        "US_EAST_2",
+        "US_WEST_1",
+        "US_WEST_2",
+        "EU_WEST_1",
+        "EU_WEST_2",
+        "EU_CENTRAL_1",
+        "AP_SOUTH_1",
+        "AP_SOUTHEAST_1",
+        "AP_SOUTHEAST_2",
+        "AP_NORTHEAST_1",
+        "AP_NORTHEAST_2",
+        "SA_EAST_1",
+        "CN_NORTH_1",
+        "CA_CENTRAL_1"
+      ]
+    }
+  },
+  "title": "KmsValue",
+  "required": [
+    "type",
+    "value",
+    "region"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+                <div class="box-container" boxid="2">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-2">
+        <div class="box-title" ref="">
+            <div class="box-name ">StringValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">StringValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "StringValue"
+      ],
+      "default": "StringValue"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "StringValue",
+  "required": [
+    "type",
+    "value"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
             </div>
         </div>
         <div class="signature">
@@ -5024,6 +5892,69 @@ function sourceButton(element) {
 </div>
             </div>
             <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_string_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-string">
+                string
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
             </div>
         </div>
 
@@ -5102,18 +6033,38 @@ function sourceButton(element) {
     "http_headers": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/KmsValueConfig"
+          },
+          {
+            "$ref": "#/definitions/StringValueConfig"
+          }
+        ]
       },
-      "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+      "description": "HTTP headers to include."
     },
     "token": {
-      "type": "string",
-      "description": "Scalyr auth token. If value is kms encrypted prefix with 'KMS='."
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KmsValueConfig"
+        },
+        {
+          "$ref": "#/definitions/StringValueConfig"
+        }
+      ],
+      "description": "Scalyr auth token."
     },
     "parser": {
       "type": "string",
       "default": "json",
       "description": "Scalyr String Parser."
+    },
+    "http_string_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "title": "Scalyr",
@@ -5351,8 +6302,8 @@ function sourceButton(element) {
 
                             <span class="type-keyword">map</span>
         <span class="type-keyword"></span>
-            <span class="signature-type-string">
-                string
+            <span class="signature-type-">
+                
             </span>
             <span class="type-keyword">
                 
@@ -5360,7 +6311,7 @@ function sourceButton(element) {
             <br>
 
                 </div>
-                <div class="signature-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+                <div class="signature-description desc"><p>HTTP headers to include.</p>
 </div>
             </div>
             <div class="signature-box-container">
@@ -5369,7 +6320,7 @@ function sourceButton(element) {
     <div class="box-header box-1">
         <div class="box-title" ref="">
             
-            <div class="box-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+            <div class="box-description desc"><p>HTTP headers to include.</p>
 </div>
             <div class="end"></div>
         </div>
@@ -5398,9 +6349,16 @@ function sourceButton(element) {
         <pre class="json-schema">{
   "type": "object",
   "additionalProperties": {
-    "type": "string"
+    "oneOf": [
+      {
+        "$ref": "#/definitions/KmsValueConfig"
+      },
+      {
+        "$ref": "#/definitions/StringValueConfig"
+      }
+    ]
   },
-  "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+  "description": "HTTP headers to include."
 }</pre>
     </div>
 </div>
@@ -5413,6 +6371,58 @@ function sourceButton(element) {
             <div class="signature-header">
                 <div class="property-name required">auth_token</div>
                 <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">KmsValue</span>
+        <span class="type-keyword"></span>
+                <span boxid="2" class="box-2 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"><p>Sumo Logic auth token. This is suffix of the http source url starting after '/receiver/v1/http/'.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">KmsValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">KmsValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">KmsValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
                                    <span class="signature-type-string">
                string
             </span>
@@ -5421,10 +6431,248 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"><p>Sumo Logic auth token. This is suffix of the http source url starting after '/receiver/v1/http/'. If value is kms encrypted prefix with 'KMS='.</p>
-</div>
+                <div class="signature-description desc"></div>
             </div>
             <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">region</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">enum</span>
+                <span class="type-enum">GovCloud</span>
+                <span class="type-enum">US_EAST_1</span>
+                <span class="type-enum">US_EAST_2</span>
+                <span class="type-enum">US_WEST_1</span>
+                <span class="type-enum">US_WEST_2</span>
+                <span class="type-enum">EU_WEST_1</span>
+                <span class="type-enum">EU_WEST_2</span>
+                <span class="type-enum">EU_CENTRAL_1</span>
+                <span class="type-enum">AP_SOUTH_1</span>
+                <span class="type-enum">AP_SOUTHEAST_1</span>
+                <span class="type-enum">AP_SOUTHEAST_2</span>
+                <span class="type-enum">AP_NORTHEAST_1</span>
+                <span class="type-enum">AP_NORTHEAST_2</span>
+                <span class="type-enum">SA_EAST_1</span>
+                <span class="type-enum">CN_NORTH_1</span>
+                <span class="type-enum">CA_CENTRAL_1</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "KmsValue"
+      ],
+      "default": "KmsValue"
+    },
+    "value": {
+      "type": "string"
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "GovCloud",
+        "US_EAST_1",
+        "US_EAST_2",
+        "US_WEST_1",
+        "US_WEST_2",
+        "EU_WEST_1",
+        "EU_WEST_2",
+        "EU_CENTRAL_1",
+        "AP_SOUTH_1",
+        "AP_SOUTHEAST_1",
+        "AP_SOUTHEAST_2",
+        "AP_NORTHEAST_1",
+        "AP_NORTHEAST_2",
+        "SA_EAST_1",
+        "CN_NORTH_1",
+        "CA_CENTRAL_1"
+      ]
+    }
+  },
+  "title": "KmsValue",
+  "required": [
+    "type",
+    "value",
+    "region"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+                <div class="box-container" boxid="2">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-2">
+        <div class="box-title" ref="">
+            <div class="box-name ">StringValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">StringValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "StringValue"
+      ],
+      "default": "StringValue"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "StringValue",
+  "required": [
+    "type",
+    "value"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_string_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-string">
+                string
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
             </div>
         </div>
 
@@ -5502,13 +6750,33 @@ function sourceButton(element) {
     "http_headers": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/KmsValueConfig"
+          },
+          {
+            "$ref": "#/definitions/StringValueConfig"
+          }
+        ]
       },
-      "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+      "description": "HTTP headers to include."
     },
     "auth_token": {
-      "type": "string",
-      "description": "Sumo Logic auth token. This is suffix of the http source url starting after '/receiver/v1/http/'. If value is kms encrypted prefix with 'KMS='."
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KmsValueConfig"
+        },
+        {
+          "$ref": "#/definitions/StringValueConfig"
+        }
+      ],
+      "description": "Sumo Logic auth token. This is suffix of the http source url starting after '/receiver/v1/http/'."
+    },
+    "http_string_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "title": "SumoLogic",
@@ -5747,8 +7015,8 @@ function sourceButton(element) {
 
                             <span class="type-keyword">map</span>
         <span class="type-keyword"></span>
-            <span class="signature-type-string">
-                string
+            <span class="signature-type-">
+                
             </span>
             <span class="type-keyword">
                 
@@ -5756,7 +7024,7 @@ function sourceButton(element) {
             <br>
 
                 </div>
-                <div class="signature-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+                <div class="signature-description desc"><p>HTTP headers to include.</p>
 </div>
             </div>
             <div class="signature-box-container">
@@ -5765,7 +7033,7 @@ function sourceButton(element) {
     <div class="box-header box-1">
         <div class="box-title" ref="">
             
-            <div class="box-description desc"><p>HTTP headers to include. If header value starts with KMS= it will be decrypted.</p>
+            <div class="box-description desc"><p>HTTP headers to include.</p>
 </div>
             <div class="end"></div>
         </div>
@@ -5794,9 +7062,16 @@ function sourceButton(element) {
         <pre class="json-schema">{
   "type": "object",
   "additionalProperties": {
-    "type": "string"
+    "oneOf": [
+      {
+        "$ref": "#/definitions/KmsValueConfig"
+      },
+      {
+        "$ref": "#/definitions/StringValueConfig"
+      }
+    ]
   },
-  "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+  "description": "HTTP headers to include."
 }</pre>
     </div>
 </div>
@@ -5809,6 +7084,58 @@ function sourceButton(element) {
             <div class="signature-header">
                 <div class="property-name required">auth_token</div>
                 <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">KmsValue</span>
+        <span class="type-keyword"></span>
+                <span boxid="2" class="box-2 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"><p>Splunk auth token.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">KmsValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">KmsValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">KmsValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
                                    <span class="signature-type-string">
                string
             </span>
@@ -5817,10 +7144,185 @@ function sourceButton(element) {
             </span>
 
                 </div>
-                <div class="signature-description desc"><p>Splunk auth token. If value is kms encrypted prefix with 'KMS='.</p>
-</div>
+                <div class="signature-description desc"></div>
             </div>
             <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">region</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">enum</span>
+                <span class="type-enum">GovCloud</span>
+                <span class="type-enum">US_EAST_1</span>
+                <span class="type-enum">US_EAST_2</span>
+                <span class="type-enum">US_WEST_1</span>
+                <span class="type-enum">US_WEST_2</span>
+                <span class="type-enum">EU_WEST_1</span>
+                <span class="type-enum">EU_WEST_2</span>
+                <span class="type-enum">EU_CENTRAL_1</span>
+                <span class="type-enum">AP_SOUTH_1</span>
+                <span class="type-enum">AP_SOUTHEAST_1</span>
+                <span class="type-enum">AP_SOUTHEAST_2</span>
+                <span class="type-enum">AP_NORTHEAST_1</span>
+                <span class="type-enum">AP_NORTHEAST_2</span>
+                <span class="type-enum">SA_EAST_1</span>
+                <span class="type-enum">CN_NORTH_1</span>
+                <span class="type-enum">CA_CENTRAL_1</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "KmsValue"
+      ],
+      "default": "KmsValue"
+    },
+    "value": {
+      "type": "string"
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "GovCloud",
+        "US_EAST_1",
+        "US_EAST_2",
+        "US_WEST_1",
+        "US_WEST_2",
+        "EU_WEST_1",
+        "EU_WEST_2",
+        "EU_CENTRAL_1",
+        "AP_SOUTH_1",
+        "AP_SOUTHEAST_1",
+        "AP_SOUTHEAST_2",
+        "AP_NORTHEAST_1",
+        "AP_NORTHEAST_2",
+        "SA_EAST_1",
+        "CN_NORTH_1",
+        "CA_CENTRAL_1"
+      ]
+    }
+  },
+  "title": "KmsValue",
+  "required": [
+    "type",
+    "value",
+    "region"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+                <div class="box-container" boxid="2">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-2">
+        <div class="box-title" ref="">
+            <div class="box-name ">StringValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">StringValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "StringValue"
+      ],
+      "default": "StringValue"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "StringValue",
+  "required": [
+    "type",
+    "value"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
             </div>
         </div>
         <div class="signature">
@@ -5839,6 +7341,69 @@ function sourceButton(element) {
 </div>
             </div>
             <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_string_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-string">
+                string
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
             </div>
         </div>
 
@@ -5916,17 +7481,37 @@ function sourceButton(element) {
     "http_headers": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/KmsValueConfig"
+          },
+          {
+            "$ref": "#/definitions/StringValueConfig"
+          }
+        ]
       },
-      "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+      "description": "HTTP headers to include."
     },
     "auth_token": {
-      "type": "string",
-      "description": "Splunk auth token. If value is kms encrypted prefix with 'KMS='."
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KmsValueConfig"
+        },
+        {
+          "$ref": "#/definitions/StringValueConfig"
+        }
+      ],
+      "description": "Splunk auth token."
     },
     "index": {
       "type": "string",
       "description": "Splunk data index."
+    },
+    "http_string_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "title": "Splunk",
@@ -7620,9 +9205,16 @@ function sourceButton(element) {
         "http_headers": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/KmsValueConfig"
+              },
+              {
+                "$ref": "#/definitions/StringValueConfig"
+              }
+            ]
           },
-          "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+          "description": "HTTP headers to include."
         },
         "path": {
           "type": "string",
@@ -7638,7 +9230,13 @@ function sourceButton(element) {
               "$ref": "#/definitions/BasicHttpAuthConfig"
             }
           ],
-          "description": "Username and password used for use with http basic auth. If encrypting password with KMS then prefix password field with 'KMS='."
+          "description": "Username and password used for use with http basic auth."
+        },
+        "http_string_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "title": "HTTP",
@@ -7646,6 +9244,70 @@ function sourceButton(element) {
         "type",
         "hostname",
         "path"
+      ]
+    },
+    "KmsValueConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "KmsValue"
+          ],
+          "default": "KmsValue"
+        },
+        "value": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string",
+          "enum": [
+            "GovCloud",
+            "US_EAST_1",
+            "US_EAST_2",
+            "US_WEST_1",
+            "US_WEST_2",
+            "EU_WEST_1",
+            "EU_WEST_2",
+            "EU_CENTRAL_1",
+            "AP_SOUTH_1",
+            "AP_SOUTHEAST_1",
+            "AP_SOUTHEAST_2",
+            "AP_NORTHEAST_1",
+            "AP_NORTHEAST_2",
+            "SA_EAST_1",
+            "CN_NORTH_1",
+            "CA_CENTRAL_1"
+          ]
+        }
+      },
+      "title": "KmsValue",
+      "required": [
+        "type",
+        "value",
+        "region"
+      ]
+    },
+    "StringValueConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "StringValue"
+          ],
+          "default": "StringValue"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "StringValue",
+      "required": [
+        "type",
+        "value"
       ]
     },
     "BasicHttpAuthConfig": {
@@ -7663,7 +9325,14 @@ function sourceButton(element) {
           "type": "string"
         },
         "password": {
-          "type": "string"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KmsValueConfig"
+            },
+            {
+              "$ref": "#/definitions/StringValueConfig"
+            }
+          ]
         }
       },
       "title": "UserPassAuth",
@@ -7840,9 +9509,16 @@ function sourceButton(element) {
         "http_headers": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/KmsValueConfig"
+              },
+              {
+                "$ref": "#/definitions/StringValueConfig"
+              }
+            ]
           },
-          "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+          "description": "HTTP headers to include."
         },
         "auth_config": {
           "oneOf": [
@@ -7871,6 +9547,12 @@ function sourceButton(element) {
         "index_time_format": {
           "type": "string",
           "description": "Java time format to append to index name."
+        },
+        "http_string_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "use_hashid": {
           "type": "boolean",
@@ -8000,18 +9682,38 @@ function sourceButton(element) {
         "http_headers": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/KmsValueConfig"
+              },
+              {
+                "$ref": "#/definitions/StringValueConfig"
+              }
+            ]
           },
-          "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+          "description": "HTTP headers to include."
         },
         "token": {
-          "type": "string",
-          "description": "Scalyr auth token. If value is kms encrypted prefix with 'KMS='."
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KmsValueConfig"
+            },
+            {
+              "$ref": "#/definitions/StringValueConfig"
+            }
+          ],
+          "description": "Scalyr auth token."
         },
         "parser": {
           "type": "string",
           "default": "json",
           "description": "Scalyr String Parser."
+        },
+        "http_string_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "title": "Scalyr",
@@ -8089,13 +9791,33 @@ function sourceButton(element) {
         "http_headers": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/KmsValueConfig"
+              },
+              {
+                "$ref": "#/definitions/StringValueConfig"
+              }
+            ]
           },
-          "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+          "description": "HTTP headers to include."
         },
         "auth_token": {
-          "type": "string",
-          "description": "Sumo Logic auth token. This is suffix of the http source url starting after '/receiver/v1/http/'. If value is kms encrypted prefix with 'KMS='."
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KmsValueConfig"
+            },
+            {
+              "$ref": "#/definitions/StringValueConfig"
+            }
+          ],
+          "description": "Sumo Logic auth token. This is suffix of the http source url starting after '/receiver/v1/http/'."
+        },
+        "http_string_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "title": "SumoLogic",
@@ -8174,17 +9896,37 @@ function sourceButton(element) {
         "http_headers": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/KmsValueConfig"
+              },
+              {
+                "$ref": "#/definitions/StringValueConfig"
+              }
+            ]
           },
-          "description": "HTTP headers to include. If header value starts with KMS= it will be decrypted."
+          "description": "HTTP headers to include."
         },
         "auth_token": {
-          "type": "string",
-          "description": "Splunk auth token. If value is kms encrypted prefix with 'KMS='."
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KmsValueConfig"
+            },
+            {
+              "$ref": "#/definitions/StringValueConfig"
+            }
+          ],
+          "description": "Splunk auth token."
         },
         "index": {
           "type": "string",
           "description": "Splunk data index."
+        },
+        "http_string_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "title": "Splunk",

--- a/itests/src/test/java/com/nextdoor/bender/config/ConfigurationTest.java
+++ b/itests/src/test/java/com/nextdoor/bender/config/ConfigurationTest.java
@@ -15,10 +15,16 @@
 
 package com.nextdoor.bender.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.junit.Test;
+
+import com.nextdoor.bender.ipc.http.HttpTransportConfig;
 
 public class ConfigurationTest {
 
@@ -43,4 +49,14 @@ public class ConfigurationTest {
     }
   }
 
+  @Test
+  public void testHttpHeaderConfig() {
+    BenderConfig config = BenderConfig.load("/com/nextdoor/bender/handler/http_headers.yaml");
+    HttpTransportConfig httpConf = (HttpTransportConfig) config.getTransportConfig();
+
+    Map<String, String> expected = new LinkedHashMap<String, String>();
+    expected.put("foo", "bar");
+
+    assertEquals(expected, httpConf.getHttpStringHeaders());
+  }
 }

--- a/itests/src/test/resources/com/nextdoor/bender/handler/http_headers.yaml
+++ b/itests/src/test/resources/com/nextdoor/bender/handler/http_headers.yaml
@@ -1,0 +1,28 @@
+handler:
+  type: DummyHandlerHelper$DummyHandler
+  fail_on_exception: true
+sources:
+- name: Events
+  source_regex: foo
+  deserializer:
+    type: GenericJson
+wrapper:
+  type: KinesisWrapper
+serializer:
+  type: Json
+transport:
+  type: HTTP
+  path: /foo
+  hostname: example.com
+  basic_http_auth:
+    type: UserPassAuth
+    username: auser
+    password:
+      type: StringValue
+      value: bar
+  http_headers:
+    foo:
+      type: StringValue
+      value: bar
+reporters:
+- type: DataDog

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-lang3.version>3.4</commons-lang3.version>
     <easystream.version>1.2.15</easystream.version>
-    <fast-classpath-scanner.version>2.4.2</fast-classpath-scanner.version>
+    <fast-classpath-scanner.version>2.9.3</fast-classpath-scanner.version>
     <geoip2.version>2.10.0</geoip2.version>
     <google.gson.version>2.8.2</google.gson.version>
     <!-- Don't Change guava version. This is in place to resolve dep conflicts. -->

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http/AbstractHttpTransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http/AbstractHttpTransportFactory.java
@@ -74,7 +74,7 @@ public abstract class AbstractHttpTransportFactory implements TransportFactory {
   }
 
   protected Map<String, String> getHeaders() {
-    return this.config.getHttpHeaders();
+    return this.config.getHttpStringHeaders();
   }
 
   /**

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http/HttpTransportConfig.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http/HttpTransportConfig.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import com.nextdoor.bender.auth.HttpAuthConfig;
-import com.nextdoor.bender.auth.BasicHttpAuthConfig;
 
 @JsonTypeName("HTTP")
 public class HttpTransportConfig extends AbstractHttpTransportConfig {
@@ -31,8 +30,7 @@ public class HttpTransportConfig extends AbstractHttpTransportConfig {
   @JsonProperty(required = false)
   private Character separator = '\n';
 
-  @JsonSchemaDescription("Username and password used for use with http basic auth. If encrypting "
-      + "password with KMS then prefix password field with 'KMS='.")
+  @JsonSchemaDescription("Username and password used for use with http basic auth.")
   @JsonProperty(required = false)
   private HttpAuthConfig<?> basicHttpAuth = null;
 

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http/HttpTransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http/HttpTransportFactory.java
@@ -15,9 +15,6 @@
 
 package com.nextdoor.bender.ipc.http;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
 
@@ -45,12 +42,10 @@ public class HttpTransportFactory extends BaseHttpTransportFactory {
 
     BasicHttpAuthConfig auth = (BasicHttpAuthConfig) httpConfig.getBasicHttpAuth();
     if (auth != null) {
-      Map<String, String> headers = new HashMap<String, String>(httpConfig.getHttpHeaders());
       byte[] encodedAuth =
           Base64.encodeBase64((auth.getUsername() + ":" + auth.getPassword()).getBytes());
 
-      headers.put(HttpHeaders.AUTHORIZATION, "Basic " + new String(encodedAuth));
-      httpConfig.setHttpHeaders(headers);
+      httpConfig.addHttpHeader(HttpHeaders.AUTHORIZATION, "Basic " + new String(encodedAuth));
     }
 
     super.setConf(config);

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/scalyr/ScalyrTransportConfig.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/scalyr/ScalyrTransportConfig.java
@@ -14,14 +14,12 @@
 
 package com.nextdoor.bender.ipc.scalyr;
 
-import java.io.UnsupportedEncodingException;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.nextdoor.bender.config.value.ValueConfig;
 import com.nextdoor.bender.ipc.http.AbstractHttpTransportConfig;
-import com.nextdoor.bender.utils.Passwords;
 
 @JsonTypeName("Scalyr")
 @JsonSchemaDescription("Writes events to a Scalyr endpoint.")
@@ -32,9 +30,9 @@ public class ScalyrTransportConfig extends AbstractHttpTransportConfig {
   @JsonProperty(required = false)
   private String hostname = "www.scalyr.com";
 
-  @JsonSchemaDescription("Scalyr auth token. If value is kms encrypted prefix with 'KMS='.")
+  @JsonSchemaDescription("Scalyr auth token.")
   @JsonProperty(required = true)
-  private String token = null;
+  private ValueConfig<?> token = null;
 
   @JsonSchemaDescription("Scalyr String Parser.")
   @JsonSchemaDefault(value = "json")
@@ -49,22 +47,11 @@ public class ScalyrTransportConfig extends AbstractHttpTransportConfig {
     this.hostname = hostname;
   }
 
-  public void setToken(String token) {
+  public void setToken(ValueConfig<?> token) {
     this.token = token;
   }
 
-  public String getToken() {
-    /*
-     * Decrypt token using KMS automatically.
-     */
-    if (this.token != null) {
-      try {
-        return Passwords.getPassword(this.token);
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
+  public ValueConfig<?> getToken() {
     return token;
   }
 

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/splunk/SplunkTransportConfig.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/splunk/SplunkTransportConfig.java
@@ -15,42 +15,29 @@
 
 package com.nextdoor.bender.ipc.splunk;
 
-import java.io.UnsupportedEncodingException;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.nextdoor.bender.config.value.ValueConfig;
 import com.nextdoor.bender.ipc.http.AbstractHttpTransportConfig;
-import com.nextdoor.bender.utils.Passwords;
 
 @JsonTypeName("Splunk")
 @JsonSchemaDescription("Writes events to a Splunk HEC endpoint.")
 public class SplunkTransportConfig extends AbstractHttpTransportConfig {
 
-  @JsonSchemaDescription("Splunk auth token. If value is kms encrypted prefix with 'KMS='.")
+  @JsonSchemaDescription("Splunk auth token.")
   @JsonProperty(required = true)
-  private String authToken = null;
+  private ValueConfig<?> authToken = null;
 
   @JsonSchemaDescription("Splunk data index.")
   @JsonProperty(required = false)
   private String index = null;
 
-  public void setAuthToken(String authToken) {
+  public void setAuthToken(ValueConfig<?> authToken) {
     this.authToken = authToken;
   }
 
-  public String getAuthToken() {
-    /*
-     * Decrypt token using KMS automatically.
-     */
-    if (this.authToken != null) {
-      try {
-        return Passwords.getPassword(this.authToken);
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
+  public ValueConfig<?> getAuthToken() {
     return authToken;
   }
 

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/sumologic/SumoLogicTransportConfig.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/sumologic/SumoLogicTransportConfig.java
@@ -14,38 +14,25 @@
 
 package com.nextdoor.bender.ipc.sumologic;
 
-import java.io.UnsupportedEncodingException;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.nextdoor.bender.config.value.ValueConfig;
 import com.nextdoor.bender.ipc.http.AbstractHttpTransportConfig;
-import com.nextdoor.bender.utils.Passwords;
 
 @JsonTypeName("SumoLogic")
 @JsonSchemaDescription("Writes events to a SumoLogic endpoint.")
 public class SumoLogicTransportConfig extends AbstractHttpTransportConfig {
   @JsonSchemaDescription("Sumo Logic auth token. This is suffix of the http source url "
-      + "starting after '/receiver/v1/http/'. If value is kms encrypted prefix with 'KMS='.")
+      + "starting after '/receiver/v1/http/'.")
   @JsonProperty(required = true)
-  private String authToken = null;
+  private ValueConfig<?> authToken = null;
 
-  public String getAuthToken() {
-    /*
-     * Decrypt token using KMS automatically.
-     */
-    if (this.authToken != null) {
-      try {
-        return Passwords.getPassword(this.authToken);
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
+  public ValueConfig<?> getAuthToken() {
     return authToken;
   }
 
-  public void setAuthToken(String authToken) {
+  public void setAuthToken(ValueConfig<?> authToken) {
     this.authToken = authToken;
   }
 

--- a/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportFactoryTest.java
+++ b/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportFactoryTest.java
@@ -29,16 +29,17 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.nextdoor.bender.auth.BasicHttpAuthConfig;
+import com.nextdoor.bender.config.value.StringValueConfig;
 
 public class HttpTransportFactoryTest {
   @Test
   public void testBasicAuthHeaders() {
     HttpTransportConfig config = new HttpTransportConfig();
-    config.getHttpHeaders().put("foo", "bar");
+    config.addHttpHeader("foo", "bar");
 
     BasicHttpAuthConfig auth = new BasicHttpAuthConfig();
     auth.setUsername("foo");
-    auth.setPassword("bar");
+    auth.setPassword(new StringValueConfig("bar"));
     config.setBasicHttpAuth(auth);
 
     HttpTransportFactory factory = spy(new HttpTransportFactory());

--- a/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportTest.java
+++ b/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportTest.java
@@ -41,6 +41,7 @@ import org.apache.http.entity.ContentType;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import com.nextdoor.bender.config.BenderConfig;
 import com.nextdoor.bender.ipc.TransportException;
 
 public class HttpTransportTest {


### PR DESCRIPTION
This introduces a new concept of `StringValue` and `KmsValue` for use in configs. The driver behind this is that we need a way to specify which KMS key region to use and this does not fit in with the current method of using `value: KMS=<encrypted text>` in config properties. I think this is a bit cleaner than it was before.

Example of new config:
```
transport:
  type: HTTP
  path: /foo
  hostname: example.com
  basic_http_auth:
    type: UserPassAuth
    username: auser
    password:
      type: KmsValue
      region: US_EAST_1
      value: <encrypted value>
  http_headers:
    foo:
      type: StringValue
      value: bar
```