### PR TITLE
Fix setRegion problem with KmsValueConfig

### DIFF
--- a/core/src/main/java/com/nextdoor/bender/config/value/KmsValueConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/config/value/KmsValueConfig.java
@@ -60,6 +60,10 @@ public class KmsValueConfig extends ValueConfig<KmsValueConfig> {
     return this.value;
   }
 
+  public void setValue(String value) {
+    this.value = value;
+  }
+
   public Regions getRegion() {
     return this.region;
   }

--- a/core/src/main/java/com/nextdoor/bender/utils/Passwords.java
+++ b/core/src/main/java/com/nextdoor/bender/utils/Passwords.java
@@ -55,13 +55,12 @@ public class Passwords {
       return str;
     }
 
-    AWSKMS kms = AWSKMSClientBuilder.defaultClient();
-    kms.setRegion(region);
+    AWSKMS kms = AWSKMSClientBuilder.standard().withRegion(region.getName()).build();
 
     /*
      * The KMS ciphertext is base64 encoded and must be decoded before the request is made
      */
-    String cipherString = str.substring(4);
+    String cipherString = str;
     byte[] cipherBytes = Base64.decode(cipherString);
 
     /*


### PR DESCRIPTION
*`defaultClient` is an immutable object, so can't do `setRegion` on it. Instead, use `standard().withRegion()` to build the client for a particular region
* No need to strip the first 4 characters in KmsValue
* Missing `setValue()` in KmsValueConfig