### PR TITLE
Add a JSON Flattener Operation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1543,13 +1543,15 @@ function sourceButton(element) {
         <span class="type-keyword"></span>
                 <span boxid="4" class="box-4 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">GeoIpOperation</span>
         <span class="type-keyword"></span>
-                <span boxid="5" class="box-5 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">LowerCaseKeyOperation</span>
+                <span boxid="5" class="box-5 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">FlattenOperation</span>
         <span class="type-keyword"></span>
-                <span boxid="6" class="box-6 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">JsonRootNodeOperation</span>
+                <span boxid="6" class="box-6 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">LowerCaseKeyOperation</span>
         <span class="type-keyword"></span>
-                <span boxid="7" class="box-7 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">JsonKeyNameOperation</span>
+                <span boxid="7" class="box-7 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">JsonRootNodeOperation</span>
         <span class="type-keyword"></span>
-                <span boxid="8" class="box-8 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">PartitionOperation</span>
+                <span boxid="8" class="box-8 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">JsonKeyNameOperation</span>
+        <span class="type-keyword"></span>
+                <span boxid="9" class="box-9 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">PartitionOperation</span>
 
                 </div>
                 <div class="signature-description desc"><p>Operation configuration</p>
@@ -2026,6 +2028,98 @@ function sourceButton(element) {
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
     <div class="box-header box-5">
         <div class="box-title" ref="">
+            <div class="box-name ">FlattenOperation</div>
+            <div class="box-description desc"><p>Provided a deeply nested JSON Object, it will flatten out the object into keys with a specific separator (dot by default). For example, if the input is {"foo": {"bar": {"baz": 1}}} the operation will produce {"foo.bar.baz": 1} as the new payload.</p>
+</div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">FlattenOperation</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">FlattenOperation</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">separator</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">.</span>
+
+                </div>
+                <div class="signature-description desc"><p>Separator to be used between nested key names (typically a dot(.))</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Provided a deeply nested JSON Object, it will flatten out the object into keys with a specific separator (dot by default). For example, if the input is {\"foo\": {\"bar\": {\"baz\": 1}}} the operation will produce {\"foo.bar.baz\": 1} as the new payload.",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "FlattenOperation"
+      ],
+      "default": "FlattenOperation"
+    },
+    "separator": {
+      "type": "string",
+      "default": ".",
+      "description": "Separator to be used between nested key names (typically a dot(.))"
+    }
+  },
+  "title": "FlattenOperation",
+  "required": [
+    "type"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end"></div>
+
+                </div>
+                <div class="box-container" boxid="6">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-6">
+        <div class="box-title" ref="">
             <div class="box-name ">LowerCaseKeyOperation</div>
             <div class="box-description desc"><p>Provided a JSON object it will recursively lower case all fields.</p>
 </div>
@@ -2089,9 +2183,9 @@ function sourceButton(element) {
 <div class="end"></div>
 
                 </div>
-                <div class="box-container" boxid="6">
+                <div class="box-container" boxid="7">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-6">
+    <div class="box-header box-7">
         <div class="box-title" ref="">
             <div class="box-name ">JsonRootNodeOperation</div>
             <div class="box-description desc"><p>Provided a JSON object and a path within the object it will promote the path's element to the root position. For example if the input is {"foo": {"bar": {"baz": 1}}} and specified path $.foo.bar the operation will produce {"baz": 1} as the new payload.</p>
@@ -2179,9 +2273,9 @@ function sourceButton(element) {
 <div class="end"></div>
 
                 </div>
-                <div class="box-container" boxid="7">
+                <div class="box-container" boxid="8">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-7">
+    <div class="box-header box-8">
         <div class="box-title" ref="">
             <div class="box-name ">JsonKeyNameOperation</div>
             <div class="box-description desc"><p>Provided a JSON object it will recursively append the primitive type of the value to the key name. For example {"foo": "one", "bar": 2} will become {"foo<strong>str": "one", "bar</strong>long": 2}. The mapping is string:<strong>str, boolean:</strong>boolean, array:<strong>arr, number:</strong>long or _<em>float. It also repalces "." with "</em>" in key names. This operation is particularily useful for modifying JSON which will be written to ElasticSearch which does not allow conflicting value types for keys or "." in key names.</p>
@@ -2246,9 +2340,9 @@ function sourceButton(element) {
 <div class="end"></div>
 
                 </div>
-                <div class="box-container" boxid="8">
+                <div class="box-container" boxid="9">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-8">
+    <div class="box-header box-9">
         <div class="box-title" ref="">
             <div class="box-name ">PartitionOperation</div>
             <div class="box-description desc"><p>Sets the partition information for the Event using fields from the deserialized object. When using JSON use JsonPath format to specify fields. See <a href="https://github.com/jayway/JsonPath">https://github.com/jayway/JsonPath</a></p>
@@ -2602,6 +2696,9 @@ function sourceButton(element) {
         },
         {
           "$ref": "#/definitions/GeoIpOperationConfig"
+        },
+        {
+          "$ref": "#/definitions/FlattenOperationConfig"
         },
         {
           "$ref": "#/definitions/LowerCaseKeyOperationConfig"
@@ -8787,6 +8884,9 @@ function sourceButton(element) {
               "$ref": "#/definitions/GeoIpOperationConfig"
             },
             {
+              "$ref": "#/definitions/FlattenOperationConfig"
+            },
+            {
               "$ref": "#/definitions/LowerCaseKeyOperationConfig"
             },
             {
@@ -9031,6 +9131,29 @@ function sourceButton(element) {
         "src_field_name",
         "dst_field_name",
         "geo_lite_db"
+      ]
+    },
+    "FlattenOperationConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Provided a deeply nested JSON Object, it will flatten out the object into keys with a specific separator (dot by default). For example, if the input is {\"foo\": {\"bar\": {\"baz\": 1}}} the operation will produce {\"foo.bar.baz\": 1} as the new payload.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "FlattenOperation"
+          ],
+          "default": "FlattenOperation"
+        },
+        "separator": {
+          "type": "string",
+          "default": ".",
+          "description": "Separator to be used between nested key names (typically a dot(.))"
+        }
+      },
+      "title": "FlattenOperation",
+      "required": [
+        "type"
       ]
     },
     "LowerCaseKeyOperationConfig": {

--- a/operations/src/main/java/com/nextdoor/bender/operation/json/key/FlattenOperation.java
+++ b/operations/src/main/java/com/nextdoor/bender/operation/json/key/FlattenOperation.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2018 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.operation.json.key;
+
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.nextdoor.bender.operation.json.PayloadOperation;
+
+/**
+ * Flattens out a nested JSON Object into a simple object with only one layer of key/values.
+ */
+public class FlattenOperation extends PayloadOperation {
+    private final String separator;
+
+    public FlattenOperation(String separator) {
+        this.separator = separator;
+    }
+
+    protected void perform(JsonObject obj) {
+
+        Set<Entry<String, JsonElement>> entries = obj.entrySet();
+        Set<Entry<String, JsonElement>> orgEntries = new HashSet<Entry<String, JsonElement>>(entries);
+
+        for (Entry<String, JsonElement> entry : orgEntries) {
+            JsonElement val = entry.getValue();
+
+            if (val.isJsonPrimitive() || val.isJsonNull()) {
+                continue;
+            }
+
+            obj.remove(entry.getKey());
+            if (val.isJsonObject()) {
+                perform(obj, val.getAsJsonObject(), entry.getKey());
+            } else if (val.isJsonArray()) {
+                perform(obj, val.getAsJsonArray(), entry.getKey());
+            }
+        }
+    }
+
+    protected void perform(JsonObject obj, JsonArray nested_arr, String parent) {
+        int c = 0;
+        for (JsonElement val : nested_arr) {
+            c += 1;
+
+            String key = parent + separator + c;
+
+            if (val.isJsonArray()) {
+                perform(obj, val.getAsJsonArray(), key);
+            } else if (val.isJsonObject()) {
+                perform(obj, val.getAsJsonObject(), key);
+            } else {
+                obj.add(key, val);
+            }
+        }
+    }
+
+    protected void perform(JsonObject obj, JsonObject nested_obj, String parent) {
+        Set<Entry<String, JsonElement>> entries = nested_obj.entrySet();
+        Set<Entry<String, JsonElement>> orgEntries = new HashSet<Entry<String, JsonElement>>(entries);
+
+        for (Entry<String, JsonElement> entry : orgEntries) {
+            JsonElement val = entry.getValue();
+            String key = parent + separator + entry.getKey();
+
+            if (val.isJsonObject()) {
+                perform(obj, val.getAsJsonObject(), key);
+            } else if (val.isJsonArray()) {
+                perform(obj, val.getAsJsonArray(), key);
+            } else {
+                obj.add(key, val);
+            }
+        }
+    }
+}

--- a/operations/src/main/java/com/nextdoor/bender/operation/json/key/FlattenOperationConfig.java
+++ b/operations/src/main/java/com/nextdoor/bender/operation/json/key/FlattenOperationConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2018 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.operation.json.key;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.nextdoor.bender.operation.OperationConfig;
+
+@JsonTypeName("FlattenOperation")
+@JsonSchemaDescription("Provided a deeply nested JSON Object, it will flatten out the object "
+    + "into keys with a specific separator (dot by default). For example, if the input is "
+    + "{\"foo\": {\"bar\": {\"baz\": 1}}} the operation will produce "
+    + "{\"foo.bar.baz\": 1} as the new payload.")
+public class FlattenOperationConfig extends OperationConfig {
+
+    @JsonSchemaDescription("Separator to be used between nested key names (typically a dot(.))")
+    @JsonSchemaDefault(value = ".")
+    private String separator = ".";
+
+    @Override
+    public Class<FlattenOperationFactory> getFactoryClass() {
+        return FlattenOperationFactory.class;
+    }
+
+    public String getSeparator() {
+        return separator;
+    }
+
+    public void setSeparator(String separator) {
+        this.separator = separator;
+    }
+}

--- a/operations/src/main/java/com/nextdoor/bender/operation/json/key/FlattenOperationFactory.java
+++ b/operations/src/main/java/com/nextdoor/bender/operation/json/key/FlattenOperationFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2018 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.operation.json.key;
+
+import com.nextdoor.bender.config.AbstractConfig;
+import com.nextdoor.bender.operation.Operation;
+import com.nextdoor.bender.operation.OperationFactory;
+
+/**
+ * Create a {@link FlattenOperation}.
+ */
+public class FlattenOperationFactory implements OperationFactory {
+
+    private FlattenOperationConfig config;
+
+    public FlattenOperationFactory() {
+
+    }
+
+    @Override
+    public Operation newInstance() {
+        return new FlattenOperation(this.config.getSeparator());
+    }
+
+    @Override
+    public Class getChildClass() {
+        return FlattenOperation.class;
+    }
+
+    @Override
+    public void setConf(AbstractConfig config) {
+        this.config = (FlattenOperationConfig) config;
+    }
+}

--- a/operations/src/test/java/com/nextdoor/bender/operations/json/key/FlattenOperationTest.java
+++ b/operations/src/test/java/com/nextdoor/bender/operations/json/key/FlattenOperationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Nextdoor.com, Inc
+ */
+
+package com.nextdoor.bender.operations.json.key;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.nextdoor.bender.InternalEvent;
+import com.nextdoor.bender.operation.OperationException;
+import com.nextdoor.bender.operation.json.key.FlattenOperation;
+import com.nextdoor.bender.operations.json.OperationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlattenOperationTest extends OperationTest {
+
+  @Test
+  public void testMutatePayload() throws JsonSyntaxException, IOException, OperationException {
+    JsonParser parser = new JsonParser();
+    JsonElement input = parser.parse(getResourceString("flatten_input.json"));
+    String expectedOutput = getResourceString("flatten_output.json");
+
+    DummpyEvent devent = new DummpyEvent();
+    devent.payload = input.getAsJsonObject();
+
+    FlattenOperation operation = new FlattenOperation(".");
+
+    InternalEvent ievent = new InternalEvent("", null, 0);
+    ievent.setEventObj(devent);
+    operation.perform(ievent);
+
+    assertEquals(expectedOutput, input.toString());
+  }
+}

--- a/operations/src/test/resources/com/nextdoor/bender/operations/json/key/flatten_input.json
+++ b/operations/src/test/resources/com/nextdoor/bender/operations/json/key/flatten_input.json
@@ -1,0 +1,22 @@
+{
+    "num": 123,
+    "string": "foo",
+    "float": 123.45,
+    "bool": false,
+    "null": null,
+    "complex_array": [
+        123,
+        "foo",
+        true,
+        { "nested_obj": { "key": "val" }},
+        null
+    ],
+    "simple_object": {
+        "key": "val"
+    },
+    "more_complex_object": {
+      "parent": {
+          "ha": [ 1, 2, 3 ]
+      }
+    }
+}

--- a/operations/src/test/resources/com/nextdoor/bender/operations/json/key/flatten_output.json
+++ b/operations/src/test/resources/com/nextdoor/bender/operations/json/key/flatten_output.json
@@ -1,0 +1,1 @@
+{"num":123,"string":"foo","float":123.45,"bool":false,"null":null,"complex_array.1":123,"complex_array.2":"foo","complex_array.3":true,"complex_array.4.nested_obj.key":"val","complex_array.5":null,"simple_object.key":"val","more_complex_object.parent.ha.1":1,"more_complex_object.parent.ha.2":2,"more_complex_object.parent.ha.3":3}


### PR DESCRIPTION
Takes JSON with nested arrays/objects and flattens it out into a single
layer of key/values.

Takes inbound JSON like this:

```json
{
    "num": 123,
    "string": "foo",
    "float": 123.45,
    "bool": false,
    "complex_array": [
        123,
        "foo",
        true,
        { "nested_obj": { "key": "val" }}
    ],
    "simple_object": {
        "key": "val"
    },
    "more_complex_object": {
      "parent": {
          "ha": [ 1, 2, 3 ]
      }
    }
```

and turns it into:

```json
{ 
    "num":123,  
    "string":"foo",
    "float":123.45,
    "bool":false,
    "simple_object.key":"val",
    "complex_array.1":123,
    "complex_array.2":"foo",
    "complex_array.3":true,
    "complex_array.4.nested_obj.key":"val",
    "more_complex_object.parent.ha.1":1,
    "more_complex_object.parent.ha.2":2,
    "more_complex_object.parent.ha.3":3
}
```