### PR TITLE
WIP changes to fix Bender bug

### DIFF
--- a/core/src/main/java/com/nextdoor/bender/ipc/IpcSenderService.java
+++ b/core/src/main/java/com/nextdoor/bender/ipc/IpcSenderService.java
@@ -158,13 +158,15 @@ public class IpcSenderService extends MonitoredProcess {
     synchronized (buffers) {
       /*
        * Send what remains in the buffers.
-       * If there are errors, we will send an error at the end
+       * If there are errors, we will immediately send an error after this sync block.
        */
       this.buffers.forEach((partition, buffer) -> send(buffer, partition));
       this.buffers.clear();
     }
 
     if (this.hasUnrecoverableException.getAndSet(false)) {
+      // TODO: confirm for the s3 case that clients will need a lifecycle policy
+      //  that aborts incomplete uploads within a timeframe.
       throw new TransportException("Not all transports succeeded when sending remaining buffers in the IpcSenderService during a flush operation.");
     }
 

--- a/core/src/main/java/com/nextdoor/bender/ipc/IpcSenderService.java
+++ b/core/src/main/java/com/nextdoor/bender/ipc/IpcSenderService.java
@@ -177,21 +177,22 @@ public class IpcSenderService extends MonitoredProcess {
     }
 
     /*
-     * Collect runtime of each thread
-     */
-    this.getRuntimeStat().join();
-
-    /*
      * Some factories keep state on the transports they create. Perform any cleanup that is
      * required.
      */
     transportFactory.close();
 
     /*
-     * Fail if there are any errors so we don't close the factory and end up with partial success.
+     * Collect runtime of each thread
+     */
+    this.getRuntimeStat().join();
+
+    /*
+     * Fail if there are any errors. These can come from the add() method above or
+     * from the send() operation earlier in this method when clearing the buffers.
      */
     if (this.hasUnrecoverableException.getAndSet(false)) {
-      throw new TransportException("Not all transports succeeded when sending remaining buffers in the IpcSenderService during a flush operation.");
+      throw new TransportException("Not all transports succeeded during the handler.");
     }
 
   }

--- a/core/src/test/java/com/nextdoor/bender/handler/BaseHandlerTest.java
+++ b/core/src/test/java/com/nextdoor/bender/handler/BaseHandlerTest.java
@@ -17,8 +17,7 @@ package com.nextdoor.bender.handler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.doReturn;
@@ -34,7 +33,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
+import com.nextdoor.bender.ipc.*;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,10 +52,6 @@ import com.nextdoor.bender.config.Source;
 import com.nextdoor.bender.deserializer.DeserializationException;
 import com.nextdoor.bender.deserializer.Deserializer;
 import com.nextdoor.bender.deserializer.DeserializerProcessor;
-import com.nextdoor.bender.ipc.IpcSenderService;
-import com.nextdoor.bender.ipc.TransportBuffer;
-import com.nextdoor.bender.ipc.TransportException;
-import com.nextdoor.bender.ipc.TransportFactory;
 import com.nextdoor.bender.monitoring.Monitor;
 import com.nextdoor.bender.operation.EventOperation;
 import com.nextdoor.bender.operation.OperationException;
@@ -460,11 +458,11 @@ public class BaseHandlerTest {
   }
 
   @Test(expected = TransportException.class)
-  public void testIpcSkipsOtherBuffersOnFailure() throws Throwable {
+  public void testIpcSkipsOtherEventsOnFailure() throws Throwable {
     BaseHandler.CONFIG_FILE = "/config/handler_config.json";
     handler.skipWriteStats = true;
 
-    List<DummyEvent> events = new ArrayList<DummyEvent>(2);
+    List<DummyEvent> events = new ArrayList<>(2);
     events.add(new DummyEvent("foo", 0));
     events.add(new DummyEvent("bar", 0));
 
@@ -492,6 +490,51 @@ public class BaseHandlerTest {
       handler.handler(events, context);
     } catch (Exception e) {
       verify(spyIpc).add(any()); //only occurs once
+      verify(spyIpc).flush();
+      verify(tfSpy).close();
+      assertEquals(0, spyIpc.getSuccessCountStat().getValue());
+      throw e.getCause().getCause(); // TransportException is wrapped under HandlerException
+    }
+  }
+
+  @Test(expected = TransportException.class)
+  public void testIpcSkipsOtherEventsOnFailureInMiddleOfEvents() throws Throwable {
+    BaseHandler.CONFIG_FILE = "/config/handler_config.json";
+    handler.skipWriteStats = true;
+
+    List<DummyEvent> events = new ArrayList<>();
+    IntStream.range(0, 5).forEach(i -> events.add(new DummyEvent(StringUtils.repeat("foo", i), 0)));
+
+    TestContext context = new TestContext();
+    context.setInvokedFunctionArn("arn:aws:lambda:us-east-1:123:function:test:tag");
+    handler.init(context);
+
+    TransportBuffer tbSpy1 = spy(new ArrayTransportBuffer());
+    TransportBuffer tbSpy2 = spy(new ArrayTransportBuffer());
+    TransportBuffer tbSpy3 = spy(new ArrayTransportBuffer());
+    TransportBuffer tbSpy4 = spy(new ArrayTransportBuffer());
+    TransportBuffer tbSpy5 = spy(new ArrayTransportBuffer());
+
+    doCallRealMethod().doCallRealMethod().when(tbSpy1).add(any());
+    doCallRealMethod().doCallRealMethod().when(tbSpy2).add(any());
+    doThrow(new IllegalStateException("expected")).when(tbSpy3).add(any());
+
+    IpcSenderService spyIpc = spy(handler.getIpcService());
+    TransportFactory tfSpy = spy(spyIpc.getTransportFactory());
+
+    when(tfSpy.newTransportBuffer()).thenReturn(tbSpy1, tbSpy2, tbSpy3, tbSpy4, tbSpy5);
+
+    IpcSenderServiceTest.DummyTransporter failingTransporter = spy(new IpcSenderServiceTest.DummyTransporter());
+    doThrow(new TransportException("expected")).when(failingTransporter).sendBatch(any());
+    when(tfSpy.newInstance()).thenReturn(failingTransporter);
+
+    spyIpc.setTransportFactory(tfSpy);
+    handler.setIpcService(spyIpc);
+
+    try {
+      handler.handler(events, context);
+    } catch (Exception e) {
+      verify(spyIpc, times(3)).add(any()); //exception occurs in 3rd buffer
       verify(spyIpc).flush();
       verify(tfSpy).close();
       assertEquals(0, spyIpc.getSuccessCountStat().getValue());

--- a/core/src/test/java/com/nextdoor/bender/ipc/IpcSenderServiceTest.java
+++ b/core/src/test/java/com/nextdoor/bender/ipc/IpcSenderServiceTest.java
@@ -290,8 +290,8 @@ public class IpcSenderServiceTest {
     try {
       ipc.flush();
     } catch (TransportException e) {
-      // we expect that the factory isn't closed since the flush discovers the exception first and throws
-      verify(tfactory, never()).close();
+      // we expect that the factory is closed since the exception check is done at the end
+      verify(tfactory).close();
       throw e;
     }
 

--- a/core/src/test/java/com/nextdoor/bender/ipc/IpcSenderServiceTest.java
+++ b/core/src/test/java/com/nextdoor/bender/ipc/IpcSenderServiceTest.java
@@ -16,12 +16,7 @@
 package com.nextdoor.bender.ipc;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -277,7 +272,7 @@ public class IpcSenderServiceTest {
   @Test(expected = TransportException.class)
   public void testExceptionEscalation() throws TransportException, InterruptedException {
     DummyTransporter mockDummyTransporter = mock(DummyTransporter.class);
-    DummyTransporterFactory tfactory = new DummyTransporterFactory();
+    DummyTransporterFactory tfactory = spy(new DummyTransporterFactory());
     tfactory.transporter = mockDummyTransporter;
     doThrow(new TransportException("expected exception in test")).when(mockDummyTransporter)
         .sendBatch(any(DummyTransportBuffer.class));
@@ -288,8 +283,40 @@ public class IpcSenderServiceTest {
     /*
      * Expect shutdown to throw a TransportException when a child thread also throws as
      * TransportException
+     *
+     * flush() is required to be called since we added a single event only and the dummy transport
+     * buffer only empties the buffer with 5 events stored
      */
-    ipc.flush();
+    try {
+      ipc.flush();
+    } catch (TransportException e) {
+      // we expect that the factory isn't closed since the flush discovers the exception first and throws
+      verify(tfactory, never()).close();
+      throw e;
+    }
+
+  }
+
+  @Test(expected = TransportException.class)
+  public void testThreadExceptionDuringAdd() throws TransportException, InterruptedException {
+    DummyTransporter mockDummyTransporter = mock(DummyTransporter.class);
+    DummyTransporterFactory tfactory = new DummyTransporterFactory();
+    tfactory.transporter = mockDummyTransporter;
+
+    doThrow(new TransportException("expected exception in test")).when(mockDummyTransporter)
+            .sendBatch(any(DummyTransportBuffer.class));
+
+    IpcSenderService ipc = new IpcSenderService(tfactory);
+    // add 5 events to fill up the buffer so the next will result in a sendBatch()
+    for (int i = 0; i < 5; i++) {
+      ipc.add(mock(InternalEvent.class));
+    }
+
+    // this will trigger the sendBatch exception above
+    ipc.add(mock(InternalEvent.class));
+
+    Thread.sleep(5); // lets thread from last event complete and throw exception
+    ipc.add(mock(InternalEvent.class)); // add() checks at start for any threads that threw exceptions
   }
 
   private static class DummyEvent extends InternalEvent {

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3Transport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3Transport.java
@@ -101,7 +101,7 @@ public class S3Transport implements PartitionedTransport {
               key,
               upload.getUploadId(),
               upload.getPartCount());
-      throw new TransportException(debuggingMessage + e, e);
+      throw new TransportException(debuggingMessage, e);
     } finally {
       try {
         input.close();

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3Transport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3Transport.java
@@ -87,15 +87,21 @@ public class S3Transport implements PartitionedTransport {
     /*
      * Write out to S3. Note that the S3 client auto closes the input stream.
      */
-    UploadPartRequest req =
-        upload.getUploadPartRequest().withInputStream(input).withPartSize(streamSize);
+    UploadPartRequest req = upload.getUploadPartRequest()
+            .withInputStream(input)
+            .withPartSize(streamSize);
 
     try {
       UploadPartResult res = client.uploadPart(req);
       upload.addPartETag(res.getPartETag());
     } catch (AmazonClientException e) {
       client.abortMultipartUpload(upload.getAbortMultipartUploadRequest());
-      throw new TransportException("unable to put file" + e, e);
+      multiPartUploads.remove(key);
+      String debuggingMessage = String.format("unable to put file with key %s and uploadId %s when trying to upload part number %s, leading to exception: ",
+              key,
+              upload.getUploadId(),
+              upload.getPartCount());
+      throw new TransportException(debuggingMessage + e, e);
     } finally {
       try {
         input.close();

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3TransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3TransportFactory.java
@@ -38,8 +38,7 @@ public class S3TransportFactory implements TransportFactory {
   private S3TransportConfig config;
   private AmazonS3Client client;
 
-  private Map<String, MultiPartUpload> pendingMultiPartUploads =
-      new HashMap<String, MultiPartUpload>();
+  private Map<String, MultiPartUpload> pendingMultiPartUploads = new HashMap<>();
   private S3TransportSerializer serializer = new S3TransportSerializer();
 
   @Override
@@ -55,32 +54,33 @@ public class S3TransportFactory implements TransportFactory {
 
   @Override
   public void close() {
-    Exception e = null;
     for (MultiPartUpload upload : this.pendingMultiPartUploads.values()) {
-
-      if (e == null) {
-        CompleteMultipartUploadRequest req = upload.getCompleteMultipartUploadRequest();
-        try {
-          this.client.completeMultipartUpload(req);
-        } catch (AmazonS3Exception e1) {
-          logger.error("failed to complete multi-part upload for " + upload.getKey() + " parts "
-              + upload.getPartCount(), e1);
-          e = e1;
-        }
-      } else {
-        logger.warn("aborting upload for: " + upload.getKey());
-        AbortMultipartUploadRequest req = upload.getAbortMultipartUploadRequest();
-        try {
-          this.client.abortMultipartUpload(req);
-        } catch (AmazonS3Exception e1) {
-          logger.error("failed to abort multi-part upload", e1);
-        }
+      CompleteMultipartUploadRequest req = upload.getCompleteMultipartUploadRequest();
+      try {
+        this.client.completeMultipartUpload(req);
+      } catch (AmazonS3Exception e) {
+        String errorMessage = String.format("failed to complete multi-part upload for key %s, uploadId %s, and partCount %s.",
+                upload.getKey(),
+                upload.getPartCount(),
+                upload.getUploadId());
+        logger.error(errorMessage, e);
+        abortAllMultiPartUploads();
+        throw new RuntimeException(errorMessage + " . All remaining uploads were aborted as a result.", e);
       }
     }
     this.pendingMultiPartUploads.clear();
+  }
 
-    if (e != null) {
-      throw new RuntimeException("failed while closing transport", e);
+  // this helper method makes a best attempt to abort all the multipart uploads
+  // whenever a single error is encountered during the close operation above.
+  private void abortAllMultiPartUploads() {
+    for (MultiPartUpload upload : this.pendingMultiPartUploads.values()) {
+      AbortMultipartUploadRequest req = upload.getAbortMultipartUploadRequest();
+      try {
+        this.client.abortMultipartUpload(req);
+      } catch (AmazonS3Exception e1) {
+        logger.error("failed to abort multi-part upload", e1);
+      }
     }
   }
 


### PR DESCRIPTION
Right now Bender has a bug where upon trying to complete a multi part upload, an error "AmazonS3Exception: The XML you provided was not well-formed" causes that upload to hang and abort the rest when the transport factory is flushed.

From looking at logs, the source of this is potentially not successfully retrying a retryable request with the following exception:
`
com.amazonaws.ResetException: The request to the service failed with a retryable reason, but resetting the request input stream has failed. See exception.getExtraInfo or debug-level logging for the original failure that caused this retry.; If the request involves an input stream, the maximum stream buffer size can be configured via request.getRequestClientOptions().setReadLimit(int)
`
The thread within the executor pool will throw the RuntimeException but this won't abort the Lambda handler itself.

While there will need to be a separate fix for this, for now we're going to try mitigating this by improving how we abort the handler early instead with the following changes:
- abort the multi part upload in S3Transport and remove from the map. instead we'll let this get handled at the end
- add logging in S3Transport for the TransportException to include partId, keyId, partNum, and input stream so when the thread throws a RuntimeException there will be more information to debug.
- when adding events, the ipc sender we will check if the TransportThread has set unrecoverable exception to true and will abort the handler earlier instead of letting the operation continue. The hope is by aborting early we will retry the payload to Lambda earlier and can validate if we don't see XML exception anymore.
- also refactored the close() method of the S3TransportFactory to immediately abort all the remaining uploads instead of storing the error and going in the loop.