### PR TITLE
set read limit to be streamsize + 1 to avoid resets

### DIFF
--- a/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3Transport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/s3/S3Transport.java
@@ -89,6 +89,7 @@ public class S3Transport implements PartitionedTransport {
      */
     UploadPartRequest req =
         upload.getUploadPartRequest().withInputStream(input).withPartSize(streamSize);
+    req.getRequestClientOptions().setReadLimit((int) (streamSize + 1));
 
     try {
       UploadPartResult res = client.uploadPart(req);


### PR DESCRIPTION
We're seeing stream reset errors. Since we know the size of the stream ahead of time we can avoid resets by setting the client buffer size to be that of the stream+1 as suggested in https://github.com/aws/aws-sdk-java/issues/427