### PR TITLE
[org.apache.httpcomponents] Upgrade from 4 -> 5 release to support HT…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,6 +54,12 @@
     </dependency>
 
     <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${httpclient.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>

--- a/core/src/main/java/com/nextdoor/bender/auth/aws/UrlSigningAuthConfig.java
+++ b/core/src/main/java/com/nextdoor/bender/auth/aws/UrlSigningAuthConfig.java
@@ -15,8 +15,7 @@
 
 package com.nextdoor.bender.auth.aws;
 
-import org.apache.http.HttpRequestInterceptor;
-
+import org.apache.hc.core5.http.HttpRequestInterceptor;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
 import com.amazonaws.auth.AWS4Signer;

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <geoip2.version>2.13.1</geoip2.version>
     <google.gson.version>2.8.6</google.gson.version>
     <guava.version>28.2-jre</guava.version>
-    <httpclient.version>4.5.12</httpclient.version>
+    <httpclient.version>5.1.3</httpclient.version>
     <jackson-annotation.version>2.10.3</jackson-annotation.version>
     <jackson-dataformat-yaml.version>2.10.3</jackson-dataformat-yaml.version>
     <jaxb.version>2.3.1</jaxb.version>

--- a/transporters/pom.xml
+++ b/transporters/pom.xml
@@ -37,8 +37,8 @@
     </dependency>
 
     <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
         <version>${httpclient.version}</version>
     </dependency>
 

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransport.java
@@ -54,9 +54,9 @@ public class ElasticSearchTransport extends HttpTransport {
      * Check responses status code of the overall bulk call. The call can succeed but have
      * individual failures which are checked later.
      */
-    if (resp.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+    if (resp.getCode() != HttpStatus.SC_OK) {
       throw new TransportException(
-          "es call failed because " + resp.getStatusLine().getReasonPhrase());
+          "es call failed because " + resp.getReasonPhrase());
     }
 
     /*
@@ -75,7 +75,7 @@ public class ElasticSearchTransport extends HttpTransport {
       esResp = gson.fromJson(responseString, EsResponse.class);
     } catch (JsonSyntaxException e) {
       throw new TransportException(
-          "es call failed because " + resp.getStatusLine().getReasonPhrase(), e);
+          "es call failed because " + resp.getReasonPhrase(), e);
     }
 
     /*
@@ -85,7 +85,7 @@ public class ElasticSearchTransport extends HttpTransport {
 
     if (esResp.items == null) {
       throw new TransportException(
-          "es call failed because " + resp.getStatusLine().getReasonPhrase());
+          "es call failed because " + resp.getReasonPhrase());
     }
 
     HashSet<String> errorTypes = new HashSet<String>();

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransport.java
@@ -17,10 +17,10 @@ package com.nextdoor.bender.ipc.es;
 
 import java.util.HashSet;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
-import org.apache.http.entity.ContentType;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.log4j.Logger;
 
 import com.google.gson.Gson;

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransportFactory.java
@@ -17,13 +17,14 @@ package com.nextdoor.bender.ipc.es;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.config.RequestConfig;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicHeader;
 
 import com.nextdoor.bender.auth.BasicHttpAuthConfig;
 import com.nextdoor.bender.auth.aws.UrlSigningAuthConfig;
@@ -31,6 +32,7 @@ import com.nextdoor.bender.ipc.TransportFactoryInitException;
 import com.nextdoor.bender.ipc.TransportSerializer;
 import com.nextdoor.bender.ipc.UnpartitionedTransport;
 import com.nextdoor.bender.ipc.http.AbstractHttpTransportFactory;
+import org.apache.hc.core5.util.Timeout;
 
 public class ElasticSearchTransportFactory extends AbstractHttpTransportFactory {
 
@@ -74,8 +76,8 @@ public class ElasticSearchTransportFactory extends AbstractHttpTransportFactory 
       }
     }
 
-    RequestConfig rc = RequestConfig.custom().setConnectTimeout(5000)
-        .setSocketTimeout(config.getTimeout()).build();
+    RequestConfig rc = RequestConfig.custom().setConnectTimeout(5000, TimeUnit.MICROSECONDS)
+        .setResponseTimeout(config.getTimeout(), TimeUnit.MICROSECONDS).build();
     cb.setDefaultRequestConfig(rc);
 
     return cb.build();
@@ -96,6 +98,6 @@ public class ElasticSearchTransportFactory extends AbstractHttpTransportFactory 
   }
 
   private HttpClientBuilder addSigningAuth(HttpClientBuilder cb, UrlSigningAuthConfig auth) {
-    return cb.addInterceptorLast(auth.getHttpInterceptor());
+    return cb.addRequestInterceptorLast(auth.getHttpInterceptor());
   }
 }

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/es/ElasticSearchTransportFactory.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 
 import com.nextdoor.bender.auth.BasicHttpAuthConfig;

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http/AbstractHttpTransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http/AbstractHttpTransportFactory.java
@@ -30,8 +30,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import org.apache.http.config.SocketConfig;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 
 import com.nextdoor.bender.config.AbstractConfig;

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http/HttpTransport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http/HttpTransport.java
@@ -19,16 +19,16 @@ import java.io.IOException;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Callable;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.ParseException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.log4j.Logger;
 
 import com.evanlennick.retry4j.CallExecutor;
@@ -89,8 +89,7 @@ public class HttpTransport implements UnpartitionedTransport {
     /*
      * Write gzip data to Entity and set content encoding to gzip
      */
-    ByteArrayEntity entity = new ByteArrayEntity(raw, ContentType.DEFAULT_BINARY);
-    entity.setContentEncoding("gzip");
+    ByteArrayEntity entity = new ByteArrayEntity(raw, ContentType.DEFAULT_BINARY, "gzip");
 
     httpPost.addHeader(new BasicHeader("Accept-Encoding", "gzip"));
     httpPost.setEntity(entity);
@@ -134,10 +133,10 @@ public class HttpTransport implements UnpartitionedTransport {
         }
 
         try {
-          responseString = EntityUtils.toString(resp.getEntity());
+          responseString = resp.toString();
         } catch (ParseException | IOException e) {
           throw new TransportException(
-              "http transport call failed because " + resp.getStatusLine().getReasonPhrase());
+              "http transport call failed because " + resp.getReasonPhrase());
         }
       } finally {
         /*

--- a/transporters/src/test/java/com/nextdoor/bender/ipc/es/ElasticSearchTransporterTest.java
+++ b/transporters/src/test/java/com/nextdoor/bender/ipc/es/ElasticSearchTransporterTest.java
@@ -27,14 +27,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.ContentType;
 import org.junit.Test;
 
 import com.google.gson.Gson;

--- a/transporters/src/test/java/com/nextdoor/bender/ipc/es/ElasticSearchTransporterTest.java
+++ b/transporters/src/test/java/com/nextdoor/bender/ipc/es/ElasticSearchTransporterTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.doThrow;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -51,11 +50,11 @@ public class ElasticSearchTransporterTest {
     StatusLine mockStatusLine = mock(StatusLine.class);
     doReturn("expected failure").when(mockStatusLine).getReasonPhrase();
     doReturn(status).when(mockStatusLine).getStatusCode();
-    doReturn(mockStatusLine).when(mockResponse).getStatusLine();
+    doReturn(mockStatusLine).when(mockResponse).getReasonPhrase();
 
     HttpEntity entity = new ByteArrayEntity(respPayload, contentType);
 
-    doReturn(entity).when(mockResponse).getEntity();
+    doReturn(entity).when(mockResponse).toString();
     doReturn(mockResponse).when(mockClient).execute(any(HttpPost.class));
 
     return mockClient;

--- a/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportTest.java
+++ b/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
@@ -41,7 +42,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import com.nextdoor.bender.config.BenderConfig;
 import com.nextdoor.bender.ipc.TransportException;
 
 public class HttpTransportTest {
@@ -54,7 +54,7 @@ public class HttpTransportTest {
     StatusLine mockStatusLine = mock(StatusLine.class);
     doReturn("expected failure").when(mockStatusLine).getReasonPhrase();
     doReturn(status).when(mockStatusLine).getStatusCode();
-    doReturn(mockStatusLine).when(mockResponse).getStatusLine();
+    doReturn(mockStatusLine).when(mockResponse).getReasonPhrase();
     EntityBuilder eb = EntityBuilder.create().setBinary(respPayload).setContentType(contentType);
 
     HttpEntity he;
@@ -65,7 +65,7 @@ public class HttpTransportTest {
       he = eb.build();
     }
 
-    doReturn(he).when(mockResponse).getEntity();
+    doReturn(he).when(mockResponse).toString();
 
     doReturn(mockResponse).when(mockClient).execute(any(HttpPost.class));
     return mockClient;
@@ -182,7 +182,7 @@ public class HttpTransportTest {
   }
 
   @Test
-  public void testHttpPostUrl() throws TransportException, IOException {
+  public void testHttpPostUrl() throws TransportException, IOException, URISyntaxException {
     byte[] respPayload = "{}".getBytes(StandardCharsets.UTF_8);
     byte[] payload = "foo".getBytes();
     String url = "https://localhost:443/foo";
@@ -195,7 +195,7 @@ public class HttpTransportTest {
     ArgumentCaptor<HttpPost> captor = ArgumentCaptor.forClass(HttpPost.class);
     verify(client, times(1)).execute(captor.capture());
 
-    assertEquals(url, captor.getValue().getURI().toString());
+    assertEquals(url, captor.getValue().getUri().toString());
   }
 
   @Test

--- a/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportTest.java
+++ b/transporters/src/test/java/com/nextdoor/bender/ipc/http/HttpTransportTest.java
@@ -29,15 +29,15 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.EntityBuilder;
-import org.apache.http.client.entity.GzipDecompressingEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.entity.EntityBuilder;
+import org.apache.hc.client5.http.entity.GzipDecompressingEntity;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.ContentType;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 


### PR DESCRIPTION
**What did I want?**

We have some internal endpoints that are now HTTP/2 only - and Bender did not support these beacuse of the old version of the Apache library in there. As of the 5.x version HTTP/2 is supported natively: https://openjdk.java.net/groups/net/httpclient/intro.html

> HTTP/2
> The Java HTTP Client supports both HTTP/1.1 and HTTP/2. By default the client will send requests using HTTP/2. Requests sent to servers that do not yet support HTTP/2 will automatically be downgraded to HTTP/1.1. Here's a summary of the major improvements that HTTP/2 brings:
> 
> Header Compression. HTTP/2 uses HPACK compression, which reduces overhead.
> Single Connection to the server, reduces the number of round trips needed to set up multiple TCP connections.
> Multiplexing. Multiple requests are allowed at the same time, on the same connection.
> Server Push. Additional future needed resources can be sent to a client.
> Binary format. More compact.
> Since HTTP/2 is the default preferred protocol, and the implementation seamlessly fallbacks to HTTP/1.1 where necessary, then the Java HTTP Client is well positioned for the future, when HTTP/2 is more widely deployed.
> 
