### PR TITLE
Add a new http transport that supports http/2

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30323,15 +30323,17 @@ function sourceButton(element) {
         <span class="type-keyword"></span>
                 <span boxid="7" class="box-7 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">HTTP</span>
         <span class="type-keyword"></span>
-                <span boxid="8" class="box-8 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">SumoLogic</span>
+                <span boxid="8" class="box-8 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">HTTP2</span>
         <span class="type-keyword"></span>
-                <span boxid="9" class="box-9 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">Splunk</span>
+                <span boxid="9" class="box-9 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">SumoLogic</span>
         <span class="type-keyword"></span>
-                <span boxid="10" class="box-10 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">Firehose</span>
+                <span boxid="10" class="box-10 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">Splunk</span>
         <span class="type-keyword"></span>
-                <span boxid="11" class="box-11 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">Datadog</span>
+                <span boxid="11" class="box-11 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">Firehose</span>
         <span class="type-keyword"></span>
-                <span boxid="12" class="box-12 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">DevNull</span>
+                <span boxid="12" class="box-12 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">Datadog</span>
+        <span class="type-keyword"></span>
+                <span boxid="13" class="box-13 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">DevNull</span>
 
                 </div>
                 <div class="signature-description desc"><p>Transport configuration</p>
@@ -33064,7 +33066,8 @@ function sourceButton(element) {
     <div class="box-header box-7">
         <div class="box-title" ref="">
             <div class="box-name ">HTTP</div>
-            <div class="box-description desc"></div>
+            <div class="box-description desc"><p>HTTP transport that only supports HTTP1/1</p>
+</div>
             <div class="end"></div>
         </div>
     </div>
@@ -33827,6 +33830,7 @@ function sourceButton(element) {
         <pre class="json-schema">{
   "type": "object",
   "additionalProperties": false,
+  "description": "HTTP transport that only supports HTTP1/1",
   "properties": {
     "type": {
       "type": "string",
@@ -33941,6 +33945,887 @@ function sourceButton(element) {
                 <div class="box-container" boxid="8">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
     <div class="box-header box-8">
+        <div class="box-title" ref="">
+            <div class="box-name ">HTTP2</div>
+            <div class="box-description desc"><p>HTTP transport that supports both HTTP/1.1 and HTTP/2. It will auto negotiate with the server.</p>
+</div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">HTTP2</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">HTTP2</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">threads</div>
+                <div class="signature-type">
+                                   <span class="signature-type-integer">
+               integer
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">5</span>
+
+                </div>
+                <div class="signature-description desc"><p>Number of concurrent transporters allowed</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">hostname</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"><p>HTTP endpoint hostname.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">port</div>
+                <div class="signature-type">
+                                   <span class="signature-type-integer">
+               integer
+            </span>
+            <span class="type-keyword">
+               [1;65535]
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">443</span>
+
+                </div>
+                <div class="signature-description desc"><p>HTTP endpoint port.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">use_ssl</div>
+                <div class="signature-type">
+                                   <span class="signature-type-boolean">
+               boolean
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">false</span>
+
+                </div>
+                <div class="signature-description desc"><p>Use SSL connections (certificates are not validated).</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">use_gzip</div>
+                <div class="signature-type">
+                                   <span class="signature-type-boolean">
+               boolean
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">false</span>
+
+                </div>
+                <div class="signature-description desc"><p>Use GZIP compression on HTTP calls.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">batch_size</div>
+                <div class="signature-type">
+                                   <span class="signature-type-integer">
+               integer
+            </span>
+            <span class="type-keyword">
+               [1;100000]
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">500</span>
+
+                </div>
+                <div class="signature-description desc"><p>Maximum number of documents in api call.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">retry_count</div>
+                <div class="signature-type">
+                                   <span class="signature-type-integer">
+               integer
+            </span>
+            <span class="type-keyword">
+               [0;10]
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">0</span>
+
+                </div>
+                <div class="signature-description desc"><p>Number of retries to make when a put failure occurs.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">retry_delay</div>
+                <div class="signature-type">
+                                   <span class="signature-type-integer">
+               integer
+            </span>
+            <span class="type-keyword">
+               [1;60000]
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">1000</span>
+
+                </div>
+                <div class="signature-description desc"><p>Initial delay between retries. If more than one retries specified exponential backoff is used.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">timeout</div>
+                <div class="signature-type">
+                                   <span class="signature-type-integer">
+               integer
+            </span>
+            <span class="type-keyword">
+               [1000;300000]
+            </span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">40000</span>
+
+                </div>
+                <div class="signature-description desc"><p>Request timeout in milliseconds</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-">
+                
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"><p>HTTP headers to include.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"><p>HTTP headers to include.</p>
+</div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "oneOf": [
+      {
+        "$ref": "#/definitions/KmsValueConfig"
+      },
+      {
+        "$ref": "#/definitions/StringValueConfig"
+      }
+    ]
+  },
+  "description": "HTTP headers to include."
+}</pre>
+    </div>
+</div>
+<div class="end">
+
+                </div>
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">path</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"><p>HTTP endpoint path and query string including leading slash '/'.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">separator</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"><p>Separator used between serialized records.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">basic_http_auth</div>
+                <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">UserPassAuth</span>
+
+                </div>
+                <div class="signature-description desc"><p>Username and password used for use with http basic auth.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">UserPassAuth</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">UserPassAuth</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">UserPassAuth</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">username</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">password</div>
+                <div class="signature-type">
+                            <span class="type-keyword">one of</span>
+        <span class="type-keyword"></span>
+                <span boxid="1" class="box-1 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">KmsValue</span>
+        <span class="type-keyword"></span>
+                <span boxid="2" class="box-2 signature-type-ref signature-button signature-type-expandable button" onclick="expand(this);">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            <div class="box-name ">KmsValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">KmsValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">KmsValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"><p>KMS encrypted value.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">region</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">enum</span>
+                <span class="type-enum">GovCloud</span>
+                <span class="type-enum">US_GOV_EAST_1</span>
+                <span class="type-enum">US_EAST_1</span>
+                <span class="type-enum">US_EAST_2</span>
+                <span class="type-enum">US_WEST_1</span>
+                <span class="type-enum">US_WEST_2</span>
+                <span class="type-enum">EU_WEST_1</span>
+                <span class="type-enum">EU_WEST_2</span>
+                <span class="type-enum">EU_WEST_3</span>
+                <span class="type-enum">EU_CENTRAL_1</span>
+                <span class="type-enum">EU_NORTH_1</span>
+                <span class="type-enum">AP_EAST_1</span>
+                <span class="type-enum">AP_SOUTH_1</span>
+                <span class="type-enum">AP_SOUTHEAST_1</span>
+                <span class="type-enum">AP_SOUTHEAST_2</span>
+                <span class="type-enum">AP_NORTHEAST_1</span>
+                <span class="type-enum">AP_NORTHEAST_2</span>
+                <span class="type-enum">SA_EAST_1</span>
+                <span class="type-enum">CN_NORTH_1</span>
+                <span class="type-enum">CN_NORTHWEST_1</span>
+                <span class="type-enum">CA_CENTRAL_1</span>
+                <span class="type-enum">ME_SOUTH_1</span>
+
+                </div>
+                <div class="signature-description desc"><p>AWS region associated with the KMS key used to encrypt the value.</p>
+</div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "KmsValue"
+      ],
+      "default": "KmsValue"
+    },
+    "value": {
+      "type": "string",
+      "description": "KMS encrypted value."
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "GovCloud",
+        "US_GOV_EAST_1",
+        "US_EAST_1",
+        "US_EAST_2",
+        "US_WEST_1",
+        "US_WEST_2",
+        "EU_WEST_1",
+        "EU_WEST_2",
+        "EU_WEST_3",
+        "EU_CENTRAL_1",
+        "EU_NORTH_1",
+        "AP_EAST_1",
+        "AP_SOUTH_1",
+        "AP_SOUTHEAST_1",
+        "AP_SOUTHEAST_2",
+        "AP_NORTHEAST_1",
+        "AP_NORTHEAST_2",
+        "SA_EAST_1",
+        "CN_NORTH_1",
+        "CN_NORTHWEST_1",
+        "CA_CENTRAL_1",
+        "ME_SOUTH_1"
+      ],
+      "description": "AWS region associated with the KMS key used to encrypt the value."
+    }
+  },
+  "title": "KmsValue",
+  "required": [
+    "type",
+    "value",
+    "region"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end">
+
+                </div>
+                <div class="box-container" boxid="2">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-2">
+        <div class="box-title" ref="">
+            <div class="box-name ">StringValue</div>
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">type</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+            <span class="type-keyword">constant</span>
+                <span class="type-enum">StringValue</span>
+            <span class="type-keyword">default</span>
+            <span class="type-default">StringValue</span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name required">value</div>
+                <div class="signature-type">
+                                   <span class="signature-type-string">
+               string
+            </span>
+            <span class="type-keyword">
+               
+            </span>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "StringValue"
+      ],
+      "default": "StringValue"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "StringValue",
+  "required": [
+    "type",
+    "value"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end">
+
+                </div>
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "UserPassAuth"
+      ],
+      "default": "UserPassAuth"
+    },
+    "username": {
+      "type": "string"
+    },
+    "password": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/KmsValueConfig"
+        },
+        {
+          "$ref": "#/definitions/StringValueConfig"
+        }
+      ]
+    }
+  },
+  "title": "UserPassAuth",
+  "required": [
+    "type",
+    "username",
+    "password"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end">
+
+                </div>
+            </div>
+        </div>
+        <div class="signature">
+            <div class="signature-header">
+                <div class="property-name ">http_string_headers</div>
+                <div class="signature-type">
+                                        <span boxid="1" class="box-1 signature-type-object signature-button signature-type-expandable button" onclick="expand(this);">object</span>
+
+                            <span class="type-keyword">map</span>
+        <span class="type-keyword"></span>
+            <span class="signature-type-string">
+                string
+            </span>
+            <span class="type-keyword">
+                
+            </span>
+            <br>
+
+                </div>
+                <div class="signature-description desc"></div>
+            </div>
+            <div class="signature-box-container">
+                <div class="box-container" boxid="1">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-1">
+        <div class="box-title" ref="">
+            
+            <div class="box-description desc"></div>
+            <div class="end"></div>
+        </div>
+    </div>
+     <div class="source-button button" title="Source" onclick="sourceButton(this);">{}</div>
+    <div class="box-body">
+        <div class="expand-button button" title="Expand all" onclick="expandButton(this);">+</div>
+        <div>
+            
+        </div>
+        <div class="container ">
+
+
+    <div class="signature">
+        <div class="signature-header">
+            <div class="property-name type-pattern">additional</div>
+            <div class="signature-type">
+                
+            </div>
+        </div>
+    </div>
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}</pre>
+    </div>
+</div>
+<div class="end">
+
+                </div>
+            </div>
+        </div>
+
+
+</div>
+
+    </div>
+    <div class="source">
+        <pre class="json-schema">{
+  "type": "object",
+  "additionalProperties": false,
+  "description": "HTTP transport that supports both HTTP/1.1 and HTTP/2. It will auto negotiate with the server.",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "HTTP2"
+      ],
+      "default": "HTTP2"
+    },
+    "threads": {
+      "type": "integer",
+      "default": 5,
+      "description": "Number of concurrent transporters allowed"
+    },
+    "hostname": {
+      "type": "string",
+      "description": "HTTP endpoint hostname."
+    },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "default": 443,
+      "description": "HTTP endpoint port."
+    },
+    "use_ssl": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use SSL connections (certificates are not validated)."
+    },
+    "use_gzip": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use GZIP compression on HTTP calls."
+    },
+    "batch_size": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100000,
+      "default": 500,
+      "description": "Maximum number of documents in api call."
+    },
+    "retry_count": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 10,
+      "default": 0,
+      "description": "Number of retries to make when a put failure occurs."
+    },
+    "retry_delay": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 60000,
+      "default": 1000,
+      "description": "Initial delay between retries. If more than one retries specified exponential backoff is used."
+    },
+    "timeout": {
+      "type": "integer",
+      "minimum": 1000,
+      "maximum": 300000,
+      "default": 40000,
+      "description": "Request timeout in milliseconds"
+    },
+    "http_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/KmsValueConfig"
+          },
+          {
+            "$ref": "#/definitions/StringValueConfig"
+          }
+        ]
+      },
+      "description": "HTTP headers to include."
+    },
+    "path": {
+      "type": "string",
+      "description": "HTTP endpoint path and query string including leading slash '/'."
+    },
+    "separator": {
+      "type": "string",
+      "description": "Separator used between serialized records."
+    },
+    "basic_http_auth": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/BasicHttpAuthConfig"
+        }
+      ],
+      "description": "Username and password used for use with http basic auth."
+    },
+    "http_string_headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "title": "HTTP2",
+  "required": [
+    "type",
+    "hostname",
+    "path"
+  ]
+}</pre>
+    </div>
+</div>
+<div class="end">
+
+                </div>
+                <div class="box-container" boxid="9">
+                     <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
+    <div class="box-header box-9">
         <div class="box-title" ref="">
             <div class="box-name ">SumoLogic</div>
             <div class="box-description desc"><p>Writes events to a SumoLogic endpoint.</p>
@@ -34667,9 +35552,9 @@ function sourceButton(element) {
 <div class="end">
 
                 </div>
-                <div class="box-container" boxid="9">
+                <div class="box-container" boxid="10">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-9">
+    <div class="box-header box-10">
         <div class="box-title" ref="">
             <div class="box-name ">Splunk</div>
             <div class="box-description desc"><p>Writes events to a Splunk HEC endpoint.</p>
@@ -35418,9 +36303,9 @@ function sourceButton(element) {
 <div class="end">
 
                 </div>
-                <div class="box-container" boxid="10">
+                <div class="box-container" boxid="11">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-10">
+    <div class="box-header box-11">
         <div class="box-title" ref="">
             <div class="box-name ">Firehose</div>
             <div class="box-description desc"><p>Transports events to AWS Kinesis Firehose. This transport is agnostic of the data being sent. However there are important limits to consider. The maximum size of a single Firehose record can not exceed 1000kb and the maximum for a batch is 4mb. Events larger than 1000kb will not be split across multiple Records. The transport contains two types of buffers. In BATCH mode it will attempt to write multiple events into a single Firehose Record in order to minimize number of Records sent. In SIMPLE mode each serialized event is putinto a its own Record. Firehose sinks like ElasticSearch require each event be its own Firehose Record.Required IAM permissions are: firehose:DescribeDeliveryStream, firehose:ListDeliveryStreams, firehose:PutRecord, firehose:PutRecordBatch</p>
@@ -35659,9 +36544,9 @@ function sourceButton(element) {
 <div class="end">
 
                 </div>
-                <div class="box-container" boxid="11">
+                <div class="box-container" boxid="12">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-11">
+    <div class="box-header box-12">
         <div class="box-title" ref="">
             <div class="box-name ">Datadog</div>
             <div class="box-description desc"><p>Writes events to a Datadog endpoint.</p>
@@ -36230,9 +37115,9 @@ function sourceButton(element) {
 <div class="end">
 
                 </div>
-                <div class="box-container" boxid="12">
+                <div class="box-container" boxid="13">
                      <div class="box" onmousedown="deSelect(); this.className += ' box-selected'; event.preventDefault(); return false;" onmouseenter="displayButtons(this, 'block');" onmouseleave="displayButtons(this, 'none');">
-    <div class="box-header box-12">
+    <div class="box-header box-13">
         <div class="box-title" ref="">
             <div class="box-name ">DevNull</div>
             <div class="box-description desc"><p>Transport for testing and development. Serialized events simply get cleared out of the transport buffer.</p>
@@ -37455,6 +38340,9 @@ function sourceButton(element) {
         },
         {
           "$ref": "#/definitions/HttpTransportConfig"
+        },
+        {
+          "$ref": "#/definitions/Http2TransportConfig"
         },
         {
           "$ref": "#/definitions/SumoLogicTransportConfig"
@@ -39785,6 +40673,7 @@ function sourceButton(element) {
     "HttpTransportConfig": {
       "type": "object",
       "additionalProperties": false,
+      "description": "HTTP transport that only supports HTTP1/1",
       "properties": {
         "type": {
           "type": "string",
@@ -39885,6 +40774,116 @@ function sourceButton(element) {
         }
       },
       "title": "HTTP",
+      "required": [
+        "type",
+        "hostname",
+        "path"
+      ]
+    },
+    "Http2TransportConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "HTTP transport that supports both HTTP/1.1 and HTTP/2. It will auto negotiate with the server.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "HTTP2"
+          ],
+          "default": "HTTP2"
+        },
+        "threads": {
+          "type": "integer",
+          "default": 5,
+          "description": "Number of concurrent transporters allowed"
+        },
+        "hostname": {
+          "type": "string",
+          "description": "HTTP endpoint hostname."
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 443,
+          "description": "HTTP endpoint port."
+        },
+        "use_ssl": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use SSL connections (certificates are not validated)."
+        },
+        "use_gzip": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use GZIP compression on HTTP calls."
+        },
+        "batch_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100000,
+          "default": 500,
+          "description": "Maximum number of documents in api call."
+        },
+        "retry_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10,
+          "default": 0,
+          "description": "Number of retries to make when a put failure occurs."
+        },
+        "retry_delay": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 60000,
+          "default": 1000,
+          "description": "Initial delay between retries. If more than one retries specified exponential backoff is used."
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 300000,
+          "default": 40000,
+          "description": "Request timeout in milliseconds"
+        },
+        "http_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/KmsValueConfig"
+              },
+              {
+                "$ref": "#/definitions/StringValueConfig"
+              }
+            ]
+          },
+          "description": "HTTP headers to include."
+        },
+        "path": {
+          "type": "string",
+          "description": "HTTP endpoint path and query string including leading slash '/'."
+        },
+        "separator": {
+          "type": "string",
+          "description": "Separator used between serialized records."
+        },
+        "basic_http_auth": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/BasicHttpAuthConfig"
+            }
+          ],
+          "description": "Username and password used for use with http basic auth."
+        },
+        "http_string_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "HTTP2",
       "required": [
         "type",
         "hostname",
@@ -40530,6 +41529,9 @@ function sourceButton(element) {
             "$ref": "#/definitions/HttpTransportConfig"
           },
           {
+            "$ref": "#/definitions/Http2TransportConfig"
+          },
+          {
             "$ref": "#/definitions/SumoLogicTransportConfig"
           },
           {
@@ -40640,6 +41642,9 @@ function sourceButton(element) {
             "$ref": "#/definitions/HttpTransportConfig"
           },
           {
+            "$ref": "#/definitions/Http2TransportConfig"
+          },
+          {
             "$ref": "#/definitions/SumoLogicTransportConfig"
           },
           {
@@ -40681,4 +41686,4 @@ function sourceButton(element) {
     </div>
 </div>
 <div class="end">
-</div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></body></html>
+</div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></div></body></html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,9 +515,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-16.1.0.tgz",
-      "integrity": "sha512-VCdVc3JI7WrGFwaentjwZsL936Gbzvi4k4y8pqWvml/7JM98oVY9mCv/WvzpPHr2NyZHXCngTiIa0Y26xufNSA==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-17.4.0.tgz",
+      "integrity": "sha512-/kPlbyQjDJa9NEOPmKSTmHOxgq+7wAMWNdU+8B9cXseQXTaF3xYAiYc9dCh3fDUxnrLR/DIqiYEQ85ICqSya8A==",
       "requires": {
         "node-bin-setup": "^1.0.0"
       }
@@ -822,8 +822,7 @@
     "uglify-js": {
       "version": "3.13.8",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
-      "optional": true
+      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <google.gson.version>2.8.6</google.gson.version>
     <guava.version>28.2-jre</guava.version>
     <httpclient.version>4.5.12</httpclient.version>
+    <httpclient5.version>5.1.3</httpclient5.version>
     <jackson-annotation.version>2.10.3</jackson-annotation.version>
     <jackson-dataformat-yaml.version>2.10.3</jackson-dataformat-yaml.version>
     <jaxb.version>2.3.1</jaxb.version>

--- a/transporters/pom.xml
+++ b/transporters/pom.xml
@@ -43,6 +43,12 @@
     </dependency>
 
     <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${httpclient5.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${google.gson.version}</version>

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/AbstractHttp2TransportConfig.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/AbstractHttp2TransportConfig.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2022 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.ipc.http2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.nextdoor.bender.config.value.StringValueConfig;
+import com.nextdoor.bender.config.value.ValueConfig;
+import com.nextdoor.bender.ipc.TransportConfig;
+
+public abstract class AbstractHttp2TransportConfig extends TransportConfig {
+
+  @JsonSchemaDescription("HTTP endpoint hostname.")
+  @JsonProperty(required = true)
+  private String hostname = null;
+
+  @JsonSchemaDescription("HTTP endpoint port.")
+  @JsonSchemaDefault(value = "443")
+  @JsonProperty(required = false)
+  @Min(1)
+  @Max(65535)
+  private Integer port = 443;
+
+  @JsonSchemaDescription("Use SSL connections (certificates are not validated).")
+  @JsonSchemaDefault(value = "false")
+  @JsonProperty(required = false)
+  private Boolean useSSL = true;
+
+  @JsonSchemaDescription("Use GZIP compression on HTTP calls.")
+  @JsonSchemaDefault(value = "false")
+  @JsonProperty(required = false)
+  private Boolean useGzip = false;
+
+  @JsonSchemaDescription("Maximum number of documents in api call.")
+  @JsonSchemaDefault(value = "500")
+  @JsonProperty(required = false)
+  @Min(1)
+  @Max(100000)
+  private Integer batchSize = 500;
+
+  @JsonSchemaDescription("Number of retries to make when a put failure occurs.")
+  @JsonSchemaDefault(value = "0")
+  @JsonProperty(required = false)
+  @Min(0)
+  @Max(10)
+  private Integer retryCount = 0;
+
+  @JsonSchemaDescription("Initial delay between retries. If more than one retries specified exponential backoff is used.")
+  @JsonSchemaDefault(value = "1000")
+  @JsonProperty(required = false)
+  @Min(1)
+  @Max(60000)
+  private Long retryDelay = 1000l;
+
+  @JsonSchemaDescription("Request timeout in milliseconds")
+  @JsonSchemaDefault(value = "40000")
+  @JsonProperty(required = false)
+  @Min(1000)
+  @Max(300000)
+  private Integer timeout = 40000;
+
+  @JsonSchemaDescription("HTTP headers to include.")
+  @JsonSchemaDefault(value = "{}")
+  @JsonProperty(required = false)
+  private Map<String, ValueConfig<?>> httpHeaders = new HashMap<String, ValueConfig<?>>(0);
+
+  public Boolean isUseSSL() {
+    return useSSL;
+  }
+
+  public void setUseSSL(Boolean useSSL) {
+    this.useSSL = useSSL;
+  }
+
+  public Boolean isUseGzip() {
+    return useGzip;
+  }
+
+  public void setUseGzip(Boolean useGzip) {
+    this.useGzip = useGzip;
+  }
+
+  public Integer getBatchSize() {
+    return batchSize;
+  }
+
+  public void setBatchSize(Integer batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public Integer getRetryCount() {
+    return retryCount;
+  }
+
+  public void setRetryCount(Integer retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  public Long getRetryDelay() {
+    return retryDelay;
+  }
+
+  public void setRetryDelay(Long retryDelay) {
+    this.retryDelay = retryDelay;
+  }
+
+  public Integer getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(Integer timeout) {
+    this.timeout = timeout;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = hostname;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public Map<String, String> getHttpStringHeaders() {
+    Map<String, String> stringHeaders = new HashMap<String, String>(this.httpHeaders.size());
+    this.httpHeaders.forEach((k, v) -> {
+      stringHeaders.put(k, v.getValue());
+    });
+
+    return stringHeaders;
+  }
+
+  public Map<String, ValueConfig<?>> getHttpHeaders() {
+    return this.httpHeaders;
+  }
+
+  public void setHttpHeaders(Map<String, ValueConfig<?>> httpHeaders) {
+    this.httpHeaders = httpHeaders;
+  }
+
+  public void addHttpHeader(String key, String value) {
+    this.httpHeaders.put(key, new StringValueConfig(value));
+  }
+}

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/AbstractHttp2TransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/AbstractHttp2TransportFactory.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2022 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.ipc.http2;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Map;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.ssl.TLS;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import com.nextdoor.bender.config.AbstractConfig;
+import com.nextdoor.bender.ipc.TransportBuffer;
+import com.nextdoor.bender.ipc.TransportException;
+import com.nextdoor.bender.ipc.TransportFactory;
+import com.nextdoor.bender.ipc.TransportFactoryInitException;
+import com.nextdoor.bender.ipc.TransportSerializer;
+import com.nextdoor.bender.ipc.UnpartitionedTransport;
+import com.nextdoor.bender.ipc.generic.GenericTransportBuffer;
+
+public abstract class AbstractHttp2TransportFactory implements TransportFactory {
+  protected AbstractHttp2TransportConfig config;
+  protected TransportSerializer serializer;
+  protected CloseableHttpAsyncClient client;
+
+  abstract protected String getPath();
+
+  abstract protected TransportSerializer getSerializer();
+
+  @Override
+  public void setConf(AbstractConfig config) {
+    this.config = (AbstractHttp2TransportConfig) config;
+    this.serializer = getSerializer();
+    this.client = getClient(this.config.isUseSSL(), this.getUrl(), this.getHeaders());
+  }
+
+  protected String getUrl() {
+    String url = "";
+    if (this.config.isUseSSL()) {
+      url += "https://";
+    } else {
+      url += "http://";
+    }
+    url += this.config.getHostname() + ":" + this.config.getPort() + this.getPath();
+
+    return url;
+  }
+
+  protected Map<String, String> getHeaders() {
+    return this.config.getHttpStringHeaders();
+  }
+
+  /**
+   * There isn't an easy way in java to trust non-self signed certs. Just allow all until java
+   * KeyStore functionality is added to Bender.
+   *
+   * @return a context that trusts all SSL certs
+   */
+  private SSLContext getSSLContext() {
+    /*
+     * Create SSLContext and TrustManager that will trust all SSL certs.
+     *
+     * Copy pasta from http://stackoverflow.com/a/4837230
+     */
+    TrustManager tm = new X509TrustManager() {
+      public void checkClientTrusted(X509Certificate[] chain, String authType)
+          throws CertificateException {}
+
+      public void checkServerTrusted(X509Certificate[] chain, String authType)
+          throws CertificateException {}
+
+      public X509Certificate[] getAcceptedIssuers() {
+        return null;
+      }
+    };
+
+    SSLContext ctx;
+    try {
+      ctx = SSLContext.getInstance("TLS");
+    } catch (NoSuchAlgorithmException e) {
+      throw new TransportFactoryInitException("JVM does not have proper libraries for TSL");
+    }
+
+    try {
+      ctx.init(null, new TrustManager[] {tm}, new java.security.SecureRandom());
+    } catch (KeyManagementException e) {
+      throw new TransportFactoryInitException("Unable to init SSLContext with TrustManager", e);
+    }
+    return ctx;
+  }
+
+  protected HttpAsyncClientBuilder getClientBuilder(boolean useSSL, String url,
+      Map<String, String> stringHeaders) {
+
+    HttpAsyncClientBuilder cb = HttpAsyncClients.custom();
+    PoolingAsyncClientConnectionManagerBuilder cmb =
+        PoolingAsyncClientConnectionManagerBuilder.create();
+
+    /*
+     * Setup SSL
+     */
+    if (useSSL) {
+      final ClientTlsStrategyBuilder tsb =
+          ClientTlsStrategyBuilder.create().setSslContext(getSSLContext())
+              .setTlsVersions(TLS.V_1_3, TLS.V_1_2).setHostnameVerifier(new HostnameVerifier() {
+                public boolean verify(String s, SSLSession sslSession) {
+                  return true;
+                }
+              });
+
+      cmb = cmb.setTlsStrategy(tsb.build());
+    }
+
+    /*
+     * Add default headers
+     */
+    ArrayList<BasicHeader> headers = new ArrayList<BasicHeader>(stringHeaders.size());
+    stringHeaders.forEach((k, v) -> headers.add(new BasicHeader(k, v)));
+    cb = cb.setDefaultHeaders(headers);
+
+    /*
+     * Pool concurrency settings
+     */
+    cmb = cmb.setMaxConnPerRoute(this.config.getThreads()).setMaxConnTotal(this.config.getThreads())
+        .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.STRICT);
+
+    /*
+     * Negotiate on HTTP version with the server
+     */
+    cb = cb.setVersionPolicy(HttpVersionPolicy.NEGOTIATE);
+
+    return cb.setConnectionManager(cmb.build());
+  }
+
+  protected CloseableHttpAsyncClient getClient(boolean useSSL, String url,
+      Map<String, String> stringHeaders) {
+    return getClientBuilder(useSSL, url, stringHeaders).build();
+  }
+
+  @Override
+  public int getMaxThreads() {
+    return this.config.getThreads();
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public UnpartitionedTransport newInstance() throws TransportFactoryInitException {
+    URL url;
+    try {
+      url = new URL(this.getUrl());
+    } catch (MalformedURLException e) {
+      throw new TransportFactoryInitException("failed parsing url: " + e.toString());
+    }
+
+    return new Http2Transport(this.client, url, this.config.isUseGzip(), this.config.getRetryCount(),
+        this.config.getRetryDelay(), this.config.getTimeout());
+  }
+
+  @Override
+  public TransportBuffer newTransportBuffer() throws TransportException {
+    try {
+      return new GenericTransportBuffer(this.config.getBatchSize(), this.config.isUseGzip(),
+          this.serializer);
+    } catch (IOException e) {
+      throw new TransportException("error creating GenericTransportBuffer", e);
+    }
+  }
+}

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/BaseHttp2TransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/BaseHttp2TransportFactory.java
@@ -1,0 +1,8 @@
+package com.nextdoor.bender.ipc.http2;
+
+public abstract class BaseHttp2TransportFactory extends AbstractHttp2TransportFactory {
+  @Override
+  public Class<Http2Transport> getChildClass() {
+    return Http2Transport.class;
+  }
+}

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2Transport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2Transport.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2022 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.ipc.http2;
+
+import java.net.URL;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.log4j.Logger;
+import com.evanlennick.retry4j.CallExecutor;
+import com.evanlennick.retry4j.RetryConfig;
+import com.evanlennick.retry4j.RetryConfigBuilder;
+import com.evanlennick.retry4j.exception.RetriesExhaustedException;
+import com.evanlennick.retry4j.exception.UnexpectedException;
+import com.nextdoor.bender.ipc.TransportBuffer;
+import com.nextdoor.bender.ipc.TransportException;
+import com.nextdoor.bender.ipc.UnpartitionedTransport;
+import com.nextdoor.bender.ipc.generic.GenericTransportBuffer;
+
+/**
+ * Generic HTTP Transport that supports HTTP/1.1 and HTTP/2. The HTTP client must be configured by
+ * your transport factory.
+ */
+public class Http2Transport implements UnpartitionedTransport {
+  private final CloseableHttpAsyncClient client;
+  protected final boolean useGzip;
+  private final long retryDelayMs;
+  private final int retries;
+  private final HttpHost target;
+  private final URL url;
+  private final long timeoutMs;
+
+  private static final Logger logger = Logger.getLogger(Http2Transport.class);
+
+  public Http2Transport(CloseableHttpAsyncClient client, URL url, boolean useGzip, int retries,
+      long retryDelayMs, long timeoutMs) {
+    this.client = client;
+    this.url = url;
+    this.useGzip = useGzip;
+    this.retries = retries;
+    this.retryDelayMs = retryDelayMs;
+    this.timeoutMs = timeoutMs;
+    this.target = new HttpHost(this.url.getProtocol(), this.url.getHost(), this.url.getPort());
+
+    this.client.start();
+  }
+
+  protected ContentType getUncompressedContentType() {
+    return ContentType.DEFAULT_TEXT;
+  }
+
+  protected SimpleHttpResponse execute(SimpleRequestBuilder rb, byte[] raw, ContentType type)
+      throws TransportException {
+    rb = rb.setBody(raw, getUncompressedContentType())
+        .setRequestConfig(RequestConfig.custom().setResponseTimeout(this.timeoutMs, TimeUnit.MILLISECONDS).build());
+
+    try {
+      final Future<SimpleHttpResponse> future =
+          client.execute(SimpleRequestProducer.create(rb.build()), SimpleResponseConsumer.create(),
+              HttpClientContext.create(), new FutureCallback<SimpleHttpResponse>() {
+
+                @Override
+                public void completed(SimpleHttpResponse result) {}
+
+                @Override
+                public void failed(Exception ex) {}
+
+                @Override
+                public void cancelled() {}
+              });
+      return future.get();
+    } catch (Exception e) {
+      throw new TransportException("failed to make call", e);
+    }
+  }
+
+  public void sendBatch(TransportBuffer buf) throws TransportException {
+    GenericTransportBuffer buffer = (GenericTransportBuffer) buf;
+    sendBatch(buffer.getInternalBuffer().toByteArray());
+  }
+
+  public void sendBatch(byte[] raw) throws TransportException {
+    /*
+     * Wrap the call with retry logic to avoid intermittent ES issues.
+     */
+    Callable<SimpleHttpResponse> callable = () -> {
+      SimpleHttpResponse resp;
+      String responseString = null;
+
+      SimpleRequestBuilder rb =
+          SimpleRequestBuilder.post().setHttpHost(this.target).setPath(this.url.getPath());
+
+
+      /*
+       * Do the call, read response, release connection so it is available for use again, and
+       * finally check the response.
+       */
+      if (this.useGzip) {
+        rb = rb.addHeader("Accept-Encoding", "gzip");
+        resp = execute(rb, raw, ContentType.DEFAULT_BINARY);
+      } else {
+        resp = execute(rb, raw, getUncompressedContentType());
+      }
+
+      responseString = resp.getBody().getBodyText();
+      checkResponse(resp, responseString);
+      return resp;
+    };
+
+    RetryConfig config = new RetryConfigBuilder()
+        .retryOnSpecificExceptions(TransportException.class).withMaxNumberOfTries(this.retries + 1)
+        .withDelayBetweenTries(this.retryDelayMs, ChronoUnit.MILLIS).withExponentialBackoff()
+        .build();
+
+    try {
+      new CallExecutor(config).execute(callable);
+    } catch (RetriesExhaustedException ree) {
+      logger.warn("transport failed after " + ree.getCallResults().getTotalTries() + " tries.");
+      throw new TransportException(ree.getCallResults().getLastExceptionThatCausedRetry());
+    } catch (UnexpectedException ue) {
+      throw new TransportException(ue);
+    }
+  }
+
+  /**
+   * Processes the response sent back by HTTP server. Override this method to implement custom
+   * response processing logic. Note connection is already released when this method is called.
+   * 
+   * @param resp Response object from server.
+   * @param responseString Response string message from server.
+   * @throws TransportException when HTTP call was unsuccessful.
+   */
+  public void checkResponse(SimpleHttpResponse resp, String responseString)
+      throws TransportException {
+    /*
+     * Check responses status code of the overall bulk call.
+     */
+    if (resp.getCode() == HttpStatus.SC_OK) {
+      return;
+    }
+
+    throw new TransportException("http transport call failed because \"" + resp.getReasonPhrase()
+        + "\" payload response \"" + responseString + "\"");
+  }
+}

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2Transport.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2Transport.java
@@ -127,7 +127,11 @@ public class Http2Transport implements UnpartitionedTransport {
         resp = execute(rb, raw, getUncompressedContentType());
       }
 
-      responseString = resp.getBody().getBodyText();
+      responseString = resp.getBodyText();
+      if (responseString == null || responseString == "") {
+        responseString = "Empty Reponse";
+      }
+
       checkResponse(resp, responseString);
       return resp;
     };

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2TransportConfig.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2TransportConfig.java
@@ -9,20 +9,21 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *
- * Copyright 2017 Nextdoor.com, Inc
+ * Copyright 2022 Nextdoor.com, Inc
  *
  */
 
-package com.nextdoor.bender.ipc.http;
+package com.nextdoor.bender.ipc.http2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
 import com.nextdoor.bender.auth.HttpAuthConfig;
 
-@JsonTypeName("HTTP")
-@JsonSchemaDescription("HTTP transport that only supports HTTP1/1")
-public class HttpTransportConfig extends AbstractHttpTransportConfig {
+@JsonTypeName("HTTP2")
+@JsonSchemaDescription("HTTP transport that supports both HTTP/1.1 and HTTP/2. It will auto "
+    + "negotiate with the server.")
+public class Http2TransportConfig extends AbstractHttp2TransportConfig {
   @JsonSchemaDescription("HTTP endpoint path and query string including leading slash '/'.")
   @JsonProperty(required = true)
   private String path = null;
@@ -61,6 +62,6 @@ public class HttpTransportConfig extends AbstractHttpTransportConfig {
 
   @Override
   public Class<?> getFactoryClass() {
-    return HttpTransportFactory.class;
+    return Http2TransportFactory.class;
   }
 }

--- a/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2TransportFactory.java
+++ b/transporters/src/main/java/com/nextdoor/bender/ipc/http2/Http2TransportFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * Copyright 2022 Nextdoor.com, Inc
+ *
+ */
+
+package com.nextdoor.bender.ipc.http2;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+
+import com.nextdoor.bender.auth.BasicHttpAuthConfig;
+import com.nextdoor.bender.config.AbstractConfig;
+import com.nextdoor.bender.ipc.TransportSerializer;
+import com.nextdoor.bender.ipc.generic.GenericTransportSerializer;
+
+public class Http2TransportFactory extends BaseHttp2TransportFactory {
+  @Override
+  protected String getPath() {
+    Http2TransportConfig config = (Http2TransportConfig) super.config;
+    return config.getPath();
+  }
+
+  @Override
+  protected TransportSerializer getSerializer() {
+    Http2TransportConfig config = (Http2TransportConfig) super.config;
+    return new GenericTransportSerializer(config.getSeparator());
+  }
+
+  @Override
+  public void setConf(AbstractConfig config) {
+    Http2TransportConfig httpConfig = (Http2TransportConfig) config;
+
+    BasicHttpAuthConfig auth = (BasicHttpAuthConfig) httpConfig.getBasicHttpAuth();
+    if (auth != null) {
+      byte[] encodedAuth =
+          Base64.encodeBase64((auth.getUsername() + ":" + auth.getPassword()).getBytes());
+
+      httpConfig.addHttpHeader(HttpHeaders.AUTHORIZATION, "Basic " + new String(encodedAuth));
+    }
+
+    super.setConf(config);
+  }
+}


### PR DESCRIPTION
Adding a new transport that is based on the v5 apache async client. The reason for creating a new one is because some of the dependent transports like ElasticSearch don't fully support the new APIs introduced by v5.